### PR TITLE
Update stopwords.yml - terms like "also known as" and "A/K/A"

### DIFF
--- a/resources/names/stopwords.yml
+++ b/resources/names/stopwords.yml
@@ -174,7 +174,20 @@ ORG_NAME_PREFIXES:
   - Le
   - La
 STOPWORDS:
+# Conjunctions/joining words
   - "de"
   - "of"
   - "and"
   - "&"
+# Terms used to indicate aliases/alternative names including old names
+- "also known as"
+- "a/k/a"
+- "A/K/A"
+- "earlier known as"
+- "formerly known as"
+- "f/k/a"
+- "F/K/A"
+- "formerly"
+- "presently known as"
+- "previously known as"
+- "trading as"


### PR DESCRIPTION
 Added terms like "also known as", "A/K/A", "previously known as" - this is part of normalisation. These are all real examples that appear on the site today. 

It would be even better of we could split the name out so that "Jennifer A/K/A Jenny" was split into two names for the same person or entity.