### PR TITLE
Add unaligned pair to sorted, not extra, then carry on aligning

### DIFF
--- a/rigour/names/alignment.py
+++ b/rigour/names/alignment.py
@@ -106,9 +106,12 @@ def align_name_slop(
         )
         # take the best of both
         if query_best is None and result_best is None:
-            # no alignment found, skip both
-            alignment.query_extra.append(query[query_index])
-            alignment.result_extra.append(result[result_index])
+            # No alignment found within slop, move forward with bad alignment
+            # unless we are at the end of either list.
+            if query_index == len(query) - 1 or result_index == len(result) - 1:
+                break
+            alignment.query_sorted.append(query[query_index])
+            alignment.result_sorted.append(result[result_index])
             query_index += 1
             result_index += 1
             continue
@@ -134,9 +137,13 @@ def align_name_slop(
         # move to the step after the aligned parts
         query_index = best.left.index + 1
         result_index = best.right.index + 1
-    # add any remaining parts to extra
-    alignment.query_extra.extend(query[query_index:])
-    alignment.result_extra.extend(result[result_index:])
+    # Add slop remaining parts to extra and the rest to sorted.
+    # We do this because max_slop parts are allowed to be ignored, but anything
+    # beyond that should penalise any similarity comparison on the sorted parts.
+    alignment.query_extra.extend(query[query_index : query_index + max_slop])
+    alignment.query_sorted.extend(query[query_index + max_slop :])
+    alignment.result_extra.extend(result[result_index : result_index + max_slop])
+    alignment.result_sorted.extend(result[result_index + max_slop :])
 
     return alignment
 

--- a/tests/names/test_alignment.py
+++ b/tests/names/test_alignment.py
@@ -69,7 +69,7 @@ def test_align_name_slop_extra_only_result():
     assert tokens_eq(amt.result_extra, ["benevolent"])
 
 
-def test_align_name_slop_extra_start():
+def test_align_name_slop_extra_start_query():
     query = make("Production Enterprise NOVI GAZMASH")
     result = make("NOVY GAZMASH")
     amt = align_name_slop(query, result, max_slop=2)
@@ -114,14 +114,14 @@ def test_align_name_slop_dont_reorder():
 
 
 def test_align_name_slop_beyond_slop():
-    # beyond slop
+    # no match within slop -> advance with unaligned parts
     query = make("Blue flowers, trees, and bird song")
     result = make("Blue bird song")
-    amt = align_name_slop(query, result)
-    assert tokens_eq(amt.query_sorted, ["blue"])
-    assert tokens_eq(amt.result_sorted, ["blue"])
-    assert tokens_eq(amt.query_extra, ["flowers", "trees", "and", "bird", "song"])
-    assert tokens_eq(amt.result_extra, ["bird", "song"])
+    amt = align_name_slop(query, result, max_slop=2)
+    assert tokens_eq(amt.query_sorted, ["blue", "flowers", "bird", "song"])
+    assert tokens_eq(amt.result_sorted, ["blue", "bird"])
+    assert tokens_eq(amt.query_extra, ["trees", "and"])
+    assert tokens_eq(amt.result_extra, ["song"])
 
     # extend slop
     amt = align_name_slop(query, result, max_slop=3)
@@ -138,7 +138,14 @@ def test_align_name_slop_trail_in_sorted():
         "Academy of Military Medical Sciences, Institute of Micobiology and Epidemiology"
     )
     amt = align_name_slop(query, result, max_slop=1)
-    assert len(amt.result_extra) + len(amt.query_extra) == 1
+    # fmt: off
+    assert tokens_eq(amt.query_sorted, ["academy", "of", "military", "medical", "sciences", "insitute", "of", "medical"])
+    assert tokens_eq(amt.result_sorted, ["academy", "of", "military", "medical", "sciences", "institute", "of", "micobiology", "epidemiology"])
+    # fmt: on
+    # slop skipped at the end
+    assert tokens_eq(amt.query_extra, ["equipment"])
+    assert tokens_eq(amt.result_extra, ["and"])
+    assert len(amt.result_extra) + len(amt.query_extra) == 2
 
 
 def test_align_slop_special_cases():


### PR DESCRIPTION
We used to add unaligned parts to extra, dropping important
signal that the strings don't align. We'll now add them to sorted,
then continue trying to match within slop. When we reach the end of the
strings, we treat the first remaining max_slop parts as valid slop,
and add the remaining unmatched parts to sorted to count against similarity

When we don't move the trailing `max_slop` items to extra before adding remaining unmatched items to sorted, we're ending the slop acceptance too early:

![image](https://github.com/user-attachments/assets/2295b7cf-2262-43df-bfa6-133a4606ace7)

Try it out like this:

```diff
diff --git a/rigour/names/alignment.py b/rigour/names/alignment.py
index 91162cb..e37e790 100644
--- a/rigour/names/alignment.py
+++ b/rigour/names/alignment.py
@@ -145,10 +145,10 @@ def align_name_slop(
     print("extend query sorted", query_index+max_slop, query[query_index+max_slop:])
     print("extend result extra", result_index, result_index+max_slop, result[result_index:result_index+max_slop])
     print("extend result sorted", result_index+max_slop, result[result_index+max_slop:])
-    alignment.query_extra.extend(query[query_index:query_index+max_slop])
-    alignment.query_sorted.extend(query[query_index+max_slop:])
-    alignment.result_extra.extend(result[result_index:result_index+max_slop])
-    alignment.result_sorted.extend(result[result_index+max_slop:])
+    #alignment.query_extra.extend(query[query_index:query_index+max_slop])
+    alignment.query_sorted.extend(query[query_index:])
+    #alignment.result_extra.extend(result[result_index:result_index+max_slop])
+    alignment.result_sorted.extend(result[result_index:])

     return alignment
```