### PR TITLE
fix the typo in 41 mappings

### DIFF
--- a/rigour/data/names/data.py
+++ b/rigour/data/names/data.py
@@ -2758,8 +2758,8 @@ ORDINALS: Dict[int, Tuple[str, ...]] = {
         "No. 41",
         "No.41",
         "No41",
-        "Vierundvierzigste",
-        "Vierundvierzigster",
+        "Einundvierzigste",
+        "Einundvierzigster",
     ),
     44: (
         "44",


### PR DESCRIPTION
fixes for:
https://www.opensanctions.org/issues/ext_icij_offshoreleaks/
https://www.opensanctions.org/issues/ext_gleif/
https://www.opensanctions.org/issues/ext_md_companies/