### PR TITLE
Add missing docstring for `fuzzy` in `lookup_territory`

### DIFF
--- a/rigour/territories/lookup.py
+++ b/rigour/territories/lookup.py
@@ -118,6 +118,7 @@ def lookup_territory(text: str, fuzzy: bool = False) -> Optional[Territory]:
 
     Args:
         text: The text to lookup, which can be a code, name, or other identifier.
+        fuzzy: If true, try a fuzzy search if the direct lookup didn't succeed.
 
     Returns:
         An instance of Territory if found, otherwise None.


### PR DESCRIPTION
Browsing the docs I noted that there was no docstring for the fuzzy argument.

https://rigour.followthemoney.tech/territories/