### PR TITLE
Update units.py - unicode fullwidth pound sign (￡)

### DIFF
--- a/rigour/units.py
+++ b/rigour/units.py
@@ -70,6 +70,7 @@ UNITS = {
     "British pound": "£",
     "pounds sterling": "£",
     "pound sterling": "£",
+    "￡": "£", # This maps the fullwidth pound sign (U+FFE1) to the pound sign (U+00A3)
     "rub": "₽",
     "rubles": "₽",
     "ruble": "₽",


### PR DESCRIPTION
See also:
https://www.compart.com/en/unicode/U+FFE1
https://www.compart.com/en/unicode/U+00A3