### PR TITLE
names: Give all name tags a sort order to avoid crash in NamePart.tag_sort

### DIFF
--- a/rigour/names/tag.py
+++ b/rigour/names/tag.py
@@ -85,5 +85,5 @@ NAME_TAGS_ORDER = (
     NamePartTag.NUM,
     NamePartTag.SUFFIX,
     NamePartTag.LEGAL,
-    NamePartTag.STOP,
+    *WILDCARDS,
 )


### PR DESCRIPTION
`NamePart.tag_sort` calls `NAME_TAGS_ORDER.index` and if there is an `AMBIGUOUS` name part, that crashes right now.