### PR TITLE
names: Map str -> Set[Symbol] in the tagger instead of a list

### DIFF
--- a/tests/names/test_tagging.py
+++ b/tests/names/test_tagging.py
@@ -123,13 +123,17 @@ def test_tag_org_name():
     assert len(tagged_name.symbols) > 0
     indus = Symbol(Symbol.Category.SYMBOL, "INDUSTRY")
     assert indus in tagged_name.symbols
-    for span in tagged_name.spans:
-        if span.symbol.category == Symbol.Category.SYMBOL:
-            continue
-        assert span.symbol.category == Symbol.Category.ORG_CLASS
-        assert span.symbol.id == "LLC"
-        for part in span.parts:
-            assert part.tag == NamePartTag.LEGAL
+
+    assert len(tagged_name.spans) == 2
+    # First span is "Doe Industries"
+    assert tagged_name.spans[0].symbol.category == Symbol.Category.SYMBOL
+
+    # Second span is "Inc." which maps to LLC
+    llc_span = tagged_name.spans[1]
+    assert llc_span.symbol.category == Symbol.Category.ORG_CLASS
+    assert llc_span.symbol.id == "LLC"
+    for part in llc_span.parts:
+        assert part.tag == NamePartTag.LEGAL
 
 
 def test_tag_org_name_location():


### PR DESCRIPTION
This makes more sense since we only want to know what symbols a name part can mean, not how many different mappings exist for that association. Since we add every single rendition under the sun of a symbol (display, normalized, multiple languages), we get quite a lot of double mappings.

The way I noticed this is that in `Tagger`, we return an entry for each Symbol, so we end up with multiple Spans being generated. For "Ltd", that's currently two (completely equal) LLC spans.
