### PR TITLE
Add Wallonia (BE-WAL) subregion for Belgium

### DIFF
--- a/resources/territories/be_wal.yml
+++ b/resources/territories/be_wal.yml
@@ -1,0 +1,18 @@
+name: Wallonia
+full_name: Walloon Region (Belgium)
+qid: Q231
+is_country: false
+is_ftm: false
+is_jurisdiction: true
+parent: be
+names_strong:
+  - Wallonie
+  - Waals Gewest
+names_weak:
+  - Région wallonne
+  - Wallonien
+  - Wallonië
+  - Valonia
+langs:
+  - fra
+  - deu


### PR DESCRIPTION
Closes #172

Adds the Walloon Region as a subregion of Belgium. Flanders (`be_vlg`) was already there, so this was the main missing piece. I don't think we need Brussels-Capital for now.

One thing I looked into: the `langs` field. Wallonia has both French and German as official languages (German is official in the East Cantons / Eupen-Malmedy area), so I included both `fra` and `deu`. Confirmed via Wikipedia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)