### PR TITLE
Add rigour.names.analyze_names as a Python shim

### DIFF
--- a/docs/names.md
+++ b/docs/names.md
@@ -1,1 +1,3 @@
 ::: rigour.names
+
+::: rigour.names.analyze

--- a/plans/rust-names-parser.md
+++ b/plans/rust-names-parser.md
@@ -141,6 +141,14 @@ Rationale for the shape:
   PyO3 as a `HashMap<NamePartTag, Vec<String>>`; enum variant discrimination
   is cheap. Open-ended: adding a new `NamePartTag` does not require an API
   change here.
+  Values may be **multi-token strings** — e.g. `part_tags[GIVEN] =
+  ["Jean Claude"]` against a name `"Jean Claude Juncker"` tags both
+  the `"jean"` and `"claude"` parts as `GIVEN`. `Name.tag_text`
+  (`rigour/names/name.py:49`) tokenises each value and walks the name
+  parts matching the sequence in order; non-adjacency is tolerated, so
+  `part_tags[GIVEN] = ["Vladimir Putin"]` would tag both parts of
+  `"Vladimir Vladimirovitch Putin"`. No extra work in the adapter —
+  feeding a raw multi-token property value works directly.
 - **No `normalizer=` callback.** Per `rust-normalizer.md`. The inside of
   `analyze_names` picks the right normalisation for each step itself.
 - **`infer_initials` instead of `is_query`.** nomenklatura historically
@@ -466,11 +474,14 @@ Benchmarks to pin before declaring Phase 5 done:
 
 Phase 5 in `rust.md` is the landing point. Incremental staging:
 
-1. **Land the rigour-side API as a Python shim first.** Once Phases 1–4 are
-   in, `rigour.names.analyze_names(names, type_tag, part_tags, *,
-   infer_initials)` can be implemented as Python glue calling the existing
-   Rust-backed primitives one by one. This lets consumers migrate before
-   Phase 5's single-FFI version exists — the API contract is the same.
+1. **Land the rigour-side API as a Python shim first.** **Done** —
+   `rigour.names.analyze_names(names, type_tag, part_tags, *,
+   infer_initials, phonetics, numerics, consolidate)` lives in
+   `rigour/names/analyze.py` and composes the existing Rust-backed
+   primitives. `phonetics` is accepted as API scaffolding with no
+   runtime effect in the Python shim (gating only kicks in at Rust
+   port time); the other three flags behave per contract. Tests in
+   `tests/names/test_analyze.py`.
 2. **Hoist the adapter into FTM.** Add `followthemoney.names.entity_names`
    with the signature above, keep `schema_type_tag` and `PROP_PART_TAGS` as
    they are (the latter becomes an implementation detail of the adapter but

--- a/plans/rust-names-parser.md
+++ b/plans/rust-names-parser.md
@@ -87,7 +87,7 @@ are no per-repo adapter copies.
 - `schema_type_tag(schema) -> NameTypeTag` (already lives here).
 - `PROP_PART_TAGS: tuple[tuple[str, NamePartTag], ...]` (already lives here).
 - **New:** `entity_names(entity, props=None, *, infer_initials=False,
-  phonetics=False, numerics=False, consolidate=False) -> set[Name]` —
+  phonetics=True, numerics=True, consolidate=True) -> set[Name]` —
   reads properties off the entity, packages them into rigour's input shape,
   and forwards to `rigour.names.analyze_names`. This is the unified
   replacement for the two near-duplicate `entity_names()` functions in
@@ -96,11 +96,13 @@ are no per-repo adapter copies.
   no concept of property names.
 
 **rigour** owns the name engine:
-- `analyze_names(names, type_tag, part_tags, *, infer_initials=False,
-  phonetics=False, numerics=False, consolidate=False) -> set[Name]` —
+- `analyze_names(type_tag, names, part_tags, *, infer_initials=False,
+  phonetics=True, numerics=True, consolidate=True) -> set[Name]` —
   single public API (Phase 5). Accepts plain strings + a
   `Mapping[NamePartTag, Sequence[str]]`. Never sees `EntityProxy`, never
-  imports FTM.
+  imports FTM. `phonetics`, `numerics`, `consolidate` default to
+  `True` (suits the matcher and the indexer's needs); `infer_initials`
+  defaults to `False` because initials are a query-side concept.
 - The primitives that underpin it (`tokenize_name`, `prenormalize_name`,
   `remove_person_prefixes`, `remove_org_prefixes`, `replace_org_types_compare`,
   `tag_org_name`, `tag_person_name`) stay importable because downstream code
@@ -119,19 +121,31 @@ becomes a re-export; the flattening to `name_parts` / `name_phonemes` /
 ### The `analyze_names` contract
 
 ```python
-# rigour/names/analysis.py  (thin Python wrapper around rigour._core._analyze_names)
+# rigour/names/analyze.py  (thin Python wrapper around rigour._core._analyze_names)
 def analyze_names(
-    names: Sequence[str],
     type_tag: NameTypeTag,
-    part_tags: Mapping[NamePartTag, Sequence[str]] = {},
+    names: Sequence[str],
+    part_tags: Optional[Mapping[NamePartTag, Sequence[str]]] = None,
     *,
     infer_initials: bool = False,
-    phonetics: bool = False,
-    numerics: bool = False,
-    consolidate: bool = False,
+    phonetics: bool = True,
+    numerics: bool = True,
+    consolidate: bool = True,
 ) -> set[Name]:
     ...
 ```
+
+Argument ordering puts `type_tag` first — the type is the most
+load-bearing piece of context for the whole call; `names` is the data
+it operates on; `part_tags` is optional annotation. Mirrors the old
+nomenklatura `entity_names(type_tag, entity, ...)` signature.
+
+`phonetics`, `numerics`, and `consolidate` default to `True` —
+suits both the matcher and the indexer's primary call shape.
+`infer_initials` defaults to `False` because initials are a
+query-side concept (only one side of a match sets them). **Indexers
+must pass `consolidate=False`** to keep partial-name recall. See
+the per-flag rationale below.
 
 Rationale for the shape:
 
@@ -166,32 +180,36 @@ Rationale for the shape:
   `entity_names` both extends `names` with `weakAlias` values *and*
   populates `part_tags[NICK]` with them. Rigour stays pure — `names` is
   just names, `part_tags` is just annotation.
-- **`consolidate` is opt-in, default `False`.** When `True`, the returned
-  set has `Name.consolidate_names` applied to it — short names that are
-  substrings of longer names in the same set are dropped. This is a
-  *matching-side* policy (prevents a short "John Smith" from spuriously
-  matching a query "John K Smith" when the longer candidate "John R
-  Smith" would correctly mismatch); the indexer must not use it or it
-  loses recall on partial-name searches. Folding consolidation into the
-  same FFI call avoids an extra Python→Rust round-trip in nomenklatura's
-  matcher, which is the call site that needs it. See Divergences row #9.
-- **`phonetics` is opt-in, default `False`.** When `True`, `NamePart.metaphone`
-  is populated (the jellyfish/rphonetic `metaphone` of the part's ASCII form,
-  gated on `latinize && !numeric && len(ascii) > 2`). When `False`, the field
-  stays `None` and the phonetics crate isn't called. Consumers that feed
-  `part.metaphone` into downstream fields — yente's `name_phonemes` ES field
-  is the live example — pass `True`. Callers that don't consume the
-  property (nomenklatura logic-v2 scoring, display pipelines, entity export,
-  enrichment) leave it off and save a metaphone call per part.
-- **`numerics` is opt-in, default `False`.** When `True`, the post-tagger
-  `_infer_part_tags` pass adds `Symbol(NUMERIC, int_value)` for numeric-
-  looking name parts that the AC tagger's ordinal list didn't already
-  match (e.g. large arbitrary numbers like `"123456789"` in `"123456789
-  Batallion"`, not the cardinals/ordinals the AC list covers). When
-  `False`, parts still get their `NamePartTag.NUM` tag (cheap structural
-  info) but no NUMERIC symbol is added — matchers that use numeric-symbol
-  overlap for disambiguation pass `True`; callers that only need the tag
-  structure leave it off.
+- **`consolidate` defaults to `True` — indexers must opt out.** When
+  `True` (default), the returned set has `Name.consolidate_names`
+  applied: short names that are substrings of longer names in the
+  same set are dropped. This is the matching-side shape (prevents a
+  short "John Smith" from spuriously matching a query "John K Smith"
+  when the longer candidate "John R Smith" would correctly
+  mismatch). **Indexer call sites must pass `consolidate=False`** to
+  preserve partial-name recall in ES; without the opt-out, yente
+  would silently lose index coverage on aliases that are substrings
+  of primary names. Folding consolidation into the same FFI call
+  avoids an extra Python→Rust round-trip in nomenklatura's matcher,
+  which is the call site that gets the default behaviour for free.
+  See Divergences row #9.
+- **`phonetics` defaults to `True`.** When `True`, `NamePart.metaphone`
+  is populated (the jellyfish/rphonetic `metaphone` of the part's ASCII
+  form, gated on `latinize && !numeric && len(ascii) > 2`). When
+  `False`, the field stays `None` and the phonetics crate isn't called.
+  Yente's indexer consumes `part.metaphone` via the `name_phonemes` ES
+  field and gets the default behaviour; nomenklatura logic-v2 scoring
+  doesn't score on phoneme overlap and can pass `False` to skip the
+  metaphone call per part (marginal saving).
+- **`numerics` defaults to `True`.** When `True`, the post-tagger
+  `_infer_part_tags` pass adds `Symbol(NUMERIC, int_value)` for
+  numeric-looking name parts that the AC tagger's ordinal list didn't
+  already match (e.g. large arbitrary numbers like `"123456789"` in
+  `"123456789 Batallion"`, not the cardinals/ordinals the AC list
+  covers). When `False`, parts still get their `NamePartTag.NUM` tag
+  (cheap structural info) but no NUMERIC symbol is added — a caller
+  that wants only the tag structure and no numeric-symbol overlap
+  scoring opts out.
 - **Return type is `set[Name]`.** Both current callsites use a set, and
   deduplication happens inside `analyze_names` anyway, so returning one is
   truth in advertising. Hashing is by the `Name` object's identity for now
@@ -293,9 +311,9 @@ def entity_names(
     props: Optional[Sequence[str]] = None,
     *,
     infer_initials: bool = False,
-    phonetics: bool = False,
-    numerics: bool = False,
-    consolidate: bool = False,
+    phonetics: bool = True,
+    numerics: bool = True,
+    consolidate: bool = True,
 ) -> Set[Name]:
     """Build Name objects from an FTM entity.
 
@@ -310,10 +328,11 @@ def entity_names(
     not contribute standalone names. Exception: `weakAlias` is both a
     standalone name and a NICK annotation on other names.
 
-    `consolidate=True` drops short names that are substrings of longer
-    names in the result set (matching-side policy — avoids a short alias
-    masking a longer-name mismatch). Indexers should leave this as
-    `False` to preserve partial-name recall.
+    `consolidate=True` (the default) drops short names that are
+    substrings of longer names in the result set (matching-side
+    policy — avoids a short alias masking a longer-name mismatch).
+    Indexers **must pass `consolidate=False`** to preserve
+    partial-name recall.
     """
     type_tag = schema_type_tag(entity.schema)
 
@@ -424,11 +443,11 @@ everyone.
 | 2 | `remove_org_prefixes` | yes | **no** | **Run it.** Yente's omission looks like a simple oversight — stripping a leading "The" is plainly the right thing for both matching and indexing. |
 | 3 | Tag parts from `PROP_PART_TAGS` (firstName→GIVEN etc.) | yes | **no** | **Run it.** Yente currently discards tag information that FTM already knows. For matching and for symbol-driven index tokens, this is information it would otherwise re-infer less accurately. |
 | 4 | `weakAlias` added to the `names` list | no | **yes** | **Keep yente's behaviour as the unified rule: treat `weakAlias` both as a full name AND as NICK-tagged parts on the main names.** Weak aliases *are* names (a crawler explicitly asserted so); they deserve their own `Name` object. Tagging them as NICK on other names is additive — FTM's `entity_names` populates both `names` and `part_tags[NICK]` with the weak-alias values. Nomenklatura gains coverage; yente keeps coverage. |
-| 5 | `is_query` / `any_initials` | yes (matching) | n/a (indexing never has a query side) | **Parameter stays but renamed to `infer_initials`** to describe the behaviour, not the caller. Default `False`; matcher sets `True` only on the query entity. Indexer always passes `False`. |
+| 5 | `is_query` / `any_initials` | yes (matching) | n/a (indexing never has a query side) | **Parameter stays but renamed to `infer_initials`** to describe the behaviour, not the caller. Default `False` — only the matcher's query side passes `True`; indexer and matcher-candidate side get the default. |
 | 6 | `@lru_cache(maxsize=200)` at the adapter | yes | no | **Cache lives on the FTM-side `entity_names` as temporary scaffolding** — until Phase 5 of `rust.md` makes the pipeline fast enough to drop it. Keyed by `EntityProxy.__hash__` (ID-only). Do not build features on top of this cache. |
 | 7 | `Symbol.Category.INITIAL` treated as non-matchable | n/a | yes (yente's `NON_MATCHABLE_SYMBOLS`) | **Move the `is_matchable` predicate onto `Symbol` in rigour** — it's semantic data about the symbol category, not an indexer policy. Yente keeps using it for index filtering; nomenklatura gets it for free if ever relevant. |
 | 8 | `fatherName` / `motherName` tagging | PATRONYMIC / MATRONYMIC | same | **Feed `fatherName` and `motherName` values into both `part_tags[MIDDLE]` and `part_tags[FAMILY]`.** These properties are genuinely ambiguous — Slavic sources use them as patronymics (structurally MIDDLE, sitting between given and family), Hispanic sources use them as additional family names (structurally FAMILY). Rather than detect locale or force crawlers to choose, tag both. The matcher aligns whichever interpretation actually fires against the candidate. No `PATRONYMIC`/`MATRONYMIC` tags produced by the FTM adapter (they remain in the `NamePartTag` enum for backwards compatibility and any future hand-tagged use). No per-call override kwargs — the multi-tag is the whole policy. |
-| 9 | `Name.consolidate_names` — drop short substring names | called *after* `entity_names` in `logic_v2/names/match.py:234-235` | **not called** | **Fold in as an opt-in `consolidate` flag on `entity_names` / `analyze_names`, defaulting `False`.** The matcher passes `True` (and drops the current explicit `Name.consolidate_names(...)` calls in `match.py`); the indexer leaves it as `False` to preserve partial-name recall in ES. Folding it inside the single FFI call keeps Phase 5's "one crossing per entity" property even for the matching side. Zavod's ExportPolicy overrides (e.g. `test_consolidate_names_never_remove_ofac_names`) are a separate dataset-level policy that consumes the primitive — unaffected by this move. |
+| 9 | `Name.consolidate_names` — drop short substring names | called *after* `entity_names` in `logic_v2/names/match.py:234-235` | **not called** | **Fold in as a `consolidate` flag on `entity_names` / `analyze_names`, defaulting `True`.** The matcher gets the default behaviour (and drops the current explicit `Name.consolidate_names(...)` calls in `match.py`); **the indexer must pass `consolidate=False`** to preserve partial-name recall in ES. Folding consolidation inside the single FFI call keeps Phase 5's "one crossing per entity" property on the matching side. Zavod's ExportPolicy overrides (e.g. `test_consolidate_names_never_remove_ofac_names`) are a separate dataset-level policy that consumes the primitive — unaffected by this move. |
 
 Items 2, 3, 4 are the biggest real changes: yente's indexed representation
 gains org-prefix stripping, property-tag hints, and weak-alias-as-name. These

--- a/rigour/names/__init__.py
+++ b/rigour/names/__init__.py
@@ -22,6 +22,7 @@ from rigour.names.tokenize import tokenize_name, prenormalize_name, normalize_na
 from rigour.names.prefix import remove_person_prefixes, remove_org_prefixes
 from rigour.names.prefix import remove_obj_prefixes
 from rigour.names.tagging import tag_person_name, tag_org_name
+from rigour.names.analyze import analyze_names
 from rigour.names.org_types import replace_org_types_display
 from rigour.names.org_types import replace_org_types_compare
 from rigour.names.org_types import extract_org_types, remove_org_types
@@ -53,5 +54,6 @@ __all__ = [
     "remove_org_types",
     "tag_person_name",
     "tag_org_name",
+    "analyze_names",
     "contains_split_phrase",
 ]

--- a/rigour/names/analyze.py
+++ b/rigour/names/analyze.py
@@ -1,0 +1,133 @@
+"""End-to-end name analysis: raw strings → tagged [Name][rigour.names.Name] objects.
+
+`analyze_names` is the unified entry point that downstream consumers
+(followthemoney's `entity_names`, in turn used by nomenklatura and
+yente) call once per entity to get matchable `Name` objects. It
+composes the existing rigour primitives —
+[prenormalize_name][rigour.names.tokenize.prenormalize_name],
+[remove_person_prefixes][rigour.names.prefix.remove_person_prefixes],
+[replace_org_types_compare][rigour.names.org_types.replace_org_types_compare],
+[remove_org_prefixes][rigour.names.prefix.remove_org_prefixes],
+[Name][rigour.names.Name] construction with part tagging via
+[Name.tag_text][rigour.names.Name.tag_text],
+[tag_org_name][rigour.names.tagging.tag_org_name] /
+[tag_person_name][rigour.names.tagging.tag_person_name],
+and optional [Name.consolidate_names][rigour.names.Name.consolidate_names]
+— into a single call so callers cross the rigour boundary once
+instead of per-primitive.
+
+## Part-tag value shape
+
+`part_tags` values can be **multi-token strings**. A value like
+``"Jean Claude"`` in ``part_tags[NamePartTag.GIVEN]`` for the name
+``"Jean Claude Juncker"`` will tag both the ``"jean"`` and
+``"claude"`` parts as `GIVEN` — `Name.tag_text` tokenises the value
+and walks the name parts looking for the token sequence. The tokens
+of the value don't need to be adjacent in the name (see
+`Name.tag_text` for the full matching rule), just present in order.
+"""
+
+from typing import Mapping, Optional, Sequence, Set
+
+from rigour.names.name import Name
+from rigour.names.org_types import replace_org_types_compare
+from rigour.names.prefix import remove_org_prefixes, remove_person_prefixes
+from rigour.names.tag import NamePartTag, NameTypeTag
+from rigour.names.tagging import tag_org_name, tag_person_name
+from rigour.names.tokenize import prenormalize_name
+
+__all__ = ["analyze_names"]
+
+
+def analyze_names(
+    names: Sequence[str],
+    type_tag: NameTypeTag,
+    part_tags: Optional[Mapping[NamePartTag, Sequence[str]]] = None,
+    *,
+    infer_initials: bool = False,
+    phonetics: bool = False,
+    numerics: bool = False,
+    consolidate: bool = False,
+) -> Set[Name]:
+    """Build a set of tagged [Name][rigour.names.Name] objects from raw strings.
+
+    Args:
+        names: Raw name strings as harvested from the source entity.
+            Empty strings and inputs that normalise to empty are
+            dropped. Duplicates (after prenormalisation) are de-duplicated.
+        type_tag: The [NameTypeTag][rigour.names.NameTypeTag] for
+            every name in this batch. Drives which prefix/org-type/
+            tagger passes run: `PER` → person prefix strip + person
+            tagger; `ORG`/`ENT` → org-type replacement + org prefix
+            strip + org tagger; `OBJ`/`UNK` → no tagging, just
+            construction.
+        part_tags: Pre-classified part annotations, typically produced
+            by an adapter that reads structured name-part properties
+            off the source entity (e.g. firstName → `GIVEN`,
+            lastName → `FAMILY`). Each value is applied to every
+            constructed `Name` via `Name.tag_text`. Values can be
+            multi-token strings — see the module docstring. Defaults
+            to an empty mapping.
+        infer_initials: Passed through to
+            [tag_person_name][rigour.names.tagging.tag_person_name].
+            When `True`, every single-character latin name part is
+            tagged with an `INITIAL` symbol (matching-query side, e.g.
+            `"J Smith"`). When `False`, only parts already tagged as
+            `GIVEN` / `MIDDLE` get `INITIAL` symbols. Ignored for non-
+            person names.
+        phonetics: Accepted for API forward-compatibility with the
+            future Rust port. In this Python shim it has **no runtime
+            effect** — `NamePart.metaphone` is a computed property
+            that always runs on access. Once the Rust port lands,
+            `phonetics=False` will skip the metaphone computation at
+            construction time; until then, callers can pass the flag
+            without behaviour change.
+        numerics: When `True`, numeric-looking name parts that the AC
+            tagger's ordinal list didn't cover get a
+            `Symbol(NUMERIC, int_value)` applied. When `False`
+            (default), parts still get `NamePartTag.NUM` (cheap
+            structural info) but no NUMERIC symbol is emitted.
+            Matchers that score on numeric-symbol overlap pass
+            `True`; display/export paths leave it off.
+        consolidate: When `True`, the returned set has
+            [Name.consolidate_names][rigour.names.Name.consolidate_names]
+            applied — short names that are substrings of longer names
+            in the same set are dropped. Matching-side policy; indexers
+            should leave this `False` to preserve partial-name recall.
+
+    Returns:
+        A set of tagged `Name` objects, de-duplicated by normalised
+        form. Empty if every input normalised to an empty string.
+    """
+    # `phonetics` is accepted but unused in this Python shim; see the
+    # Args note above. Touch the name to keep linters quiet.
+    _ = phonetics
+
+    tag_map: Mapping[NamePartTag, Sequence[str]] = part_tags or {}
+    seen: Set[str] = set()
+    result: Set[Name] = set()
+    for raw in names:
+        if type_tag == NameTypeTag.PER:
+            raw = remove_person_prefixes(raw)
+        form = prenormalize_name(raw)
+        if type_tag in (NameTypeTag.ORG, NameTypeTag.ENT):
+            form = replace_org_types_compare(form)
+            form = remove_org_prefixes(form)
+        if not form or form in seen:
+            continue
+        seen.add(form)
+        name = Name(raw, form=form, tag=type_tag)
+        for tag, values in tag_map.items():
+            for value in values:
+                name.tag_text(prenormalize_name(value), tag)
+        if type_tag in (NameTypeTag.ORG, NameTypeTag.ENT):
+            tag_org_name(name, numerics=numerics)
+        elif type_tag == NameTypeTag.PER:
+            tag_person_name(
+                name, infer_initials=infer_initials, numerics=numerics
+            )
+        # OBJ / UNK: no tagger pass — Name just wraps raw + form + parts.
+        result.add(name)
+    if consolidate:
+        return Name.consolidate_names(result)
+    return result

--- a/rigour/names/analyze.py
+++ b/rigour/names/analyze.py
@@ -40,27 +40,27 @@ __all__ = ["analyze_names"]
 
 
 def analyze_names(
-    names: Sequence[str],
     type_tag: NameTypeTag,
+    names: Sequence[str],
     part_tags: Optional[Mapping[NamePartTag, Sequence[str]]] = None,
     *,
     infer_initials: bool = False,
-    phonetics: bool = False,
-    numerics: bool = False,
-    consolidate: bool = False,
+    phonetics: bool = True,
+    numerics: bool = True,
+    consolidate: bool = True,
 ) -> Set[Name]:
     """Build a set of tagged [Name][rigour.names.Name] objects from raw strings.
 
     Args:
-        names: Raw name strings as harvested from the source entity.
-            Empty strings and inputs that normalise to empty are
-            dropped. Duplicates (after prenormalisation) are de-duplicated.
         type_tag: The [NameTypeTag][rigour.names.NameTypeTag] for
             every name in this batch. Drives which prefix/org-type/
             tagger passes run: `PER` → person prefix strip + person
             tagger; `ORG`/`ENT` → org-type replacement + org prefix
             strip + org tagger; `OBJ`/`UNK` → no tagging, just
             construction.
+        names: Raw name strings as harvested from the source entity.
+            Empty strings and inputs that normalise to empty are
+            dropped. Duplicates (after prenormalisation) are de-duplicated.
         part_tags: Pre-classified part annotations, typically produced
             by an adapter that reads structured name-part properties
             off the source entity (e.g. firstName → `GIVEN`,
@@ -71,29 +71,34 @@ def analyze_names(
         infer_initials: Passed through to
             [tag_person_name][rigour.names.tagging.tag_person_name].
             When `True`, every single-character latin name part is
-            tagged with an `INITIAL` symbol (matching-query side, e.g.
-            `"J Smith"`). When `False`, only parts already tagged as
-            `GIVEN` / `MIDDLE` get `INITIAL` symbols. Ignored for non-
-            person names.
+            tagged with an `INITIAL` symbol — useful on a free-text
+            query side where `"J Smith"` arrives without a label on
+            `"J"`. When `False` (default), only parts already tagged
+            as `GIVEN` / `MIDDLE` pick up `INITIAL` symbols. Default
+            `False` because initials are a query-side concept; the
+            indexer and the candidate side of a matcher pass `False`,
+            so the leaner default suits the common call. Ignored for
+            non-person names.
         phonetics: Accepted for API forward-compatibility with the
             future Rust port. In this Python shim it has **no runtime
             effect** — `NamePart.metaphone` is a computed property
             that always runs on access. Once the Rust port lands,
             `phonetics=False` will skip the metaphone computation at
-            construction time; until then, callers can pass the flag
-            without behaviour change.
-        numerics: When `True`, numeric-looking name parts that the AC
-            tagger's ordinal list didn't cover get a
-            `Symbol(NUMERIC, int_value)` applied. When `False`
-            (default), parts still get `NamePartTag.NUM` (cheap
-            structural info) but no NUMERIC symbol is emitted.
-            Matchers that score on numeric-symbol overlap pass
-            `True`; display/export paths leave it off.
-        consolidate: When `True`, the returned set has
+            construction time; until then, the flag is inert.
+        numerics: When `True` (default), numeric-looking name parts
+            that the AC tagger's ordinal list didn't cover get a
+            `Symbol(NUMERIC, int_value)` applied. When `False`, parts
+            still get `NamePartTag.NUM` (cheap structural info) but
+            no NUMERIC symbol is emitted. Callers that don't use
+            numeric-symbol overlap for scoring can save the symbol
+            allocation.
+        consolidate: When `True` (default), the returned set has
             [Name.consolidate_names][rigour.names.Name.consolidate_names]
             applied — short names that are substrings of longer names
-            in the same set are dropped. Matching-side policy; indexers
-            should leave this `False` to preserve partial-name recall.
+            in the same set are dropped. **Indexers should pass
+            `consolidate=False`** to preserve partial-name recall
+            (e.g. letting `"John Smith"` match `"John K Smith"` from
+            the other side).
 
     Returns:
         A set of tagged `Name` objects, de-duplicated by normalised

--- a/rigour/names/tagging.py
+++ b/rigour/names/tagging.py
@@ -44,7 +44,7 @@ __all__ = ["tag_org_name", "tag_person_name"]
 _DEFAULT_FLAGS = Normalize.CASEFOLD | Normalize.NAME
 
 
-def _infer_part_tags(name: Name) -> Name:
+def _infer_part_tags(name: Name, numerics: bool = True) -> Name:
     """Promote `UNSET` name parts based on collected symbols.
 
     Post-pass run after every tagger call:
@@ -52,11 +52,20 @@ def _infer_part_tags(name: Name) -> Name:
     * A part inside an `ORG_CLASS`-categorised span flips to
       `NamePartTag.LEGAL`; a long such span also upgrades the whole
       name's tag from `ENT` to `ORG`.
-    * A numeric-looking UNSET part flips to `NamePartTag.NUM` and
-      gains a `NUMERIC` symbol if it doesn't already have one.
+    * A numeric-looking UNSET part flips to `NamePartTag.NUM` and —
+      when `numerics=True` — gains a `NUMERIC` symbol if it doesn't
+      already have one from an ordinal/cardinal AC match.
     * An UNSET part that's a stopword flips to `NamePartTag.STOP`.
+
+    Args:
+        name: The `Name` to mutate in place.
+        numerics: If `True` (default), emit `Symbol(NUMERIC, value)`
+            for numeric-looking parts the AC tagger didn't already
+            cover. If `False`, still tag structure (`NamePartTag.NUM`)
+            but skip the symbol emission — useful for callers that
+            don't consume numeric-symbol overlap for scoring.
     """
-    numerics: Set[NamePart] = set()
+    known_numerics: Set[NamePart] = set()
     for span in name.spans:
         if span.symbol.category == Symbol.Category.ORG_CLASS:
             if name.tag == NameTypeTag.ENT and len(span) > 2:
@@ -66,17 +75,17 @@ def _infer_part_tags(name: Name) -> Name:
                     part.tag = NamePartTag.LEGAL
         if span.symbol.category == Symbol.Category.NUMERIC:
             for part in span.parts:
-                numerics.add(part)
+                known_numerics.add(part)
     for part in name.parts:
         if part.tag == NamePartTag.UNSET:
             if part.numeric:
                 part.tag = NamePartTag.NUM
-                if part not in numerics:
+                if numerics and part not in known_numerics:
                     value = part.integer
                     if value is not None:
                         sym = Symbol(Symbol.Category.NUMERIC, value)
                         name.apply_part(part, sym)
-                    numerics.add(part)
+                    known_numerics.add(part)
             elif is_stopword(part.form, normalizer=normalize_name):
                 part.tag = NamePartTag.STOP
     return name
@@ -85,6 +94,7 @@ def _infer_part_tags(name: Name) -> Name:
 def tag_org_name(
     name: Name,
     normalize_flags: Normalize = _DEFAULT_FLAGS,
+    numerics: bool = True,
 ) -> Name:
     """Tag an organisation Name with org-class + location + ordinal
     symbols.
@@ -97,6 +107,10 @@ def tag_org_name(
             runs `tokenize_name + join` as the final pipeline step,
             producing the same shape as `Name.norm_form` on the
             haystack side.
+        numerics: Forwarded to :func:`_infer_part_tags`. Default
+            `True` preserves historical behaviour (emit NUMERIC
+            symbols on arbitrary numeric parts). Pass `False` to
+            tag structure only.
 
     Returns:
         The mutated `name`.
@@ -104,13 +118,14 @@ def tag_org_name(
     matches = tag_org_matches(name.norm_form, int(normalize_flags))
     for phrase, symbol in matches:
         name.apply_phrase(phrase, symbol)
-    return _infer_part_tags(name)
+    return _infer_part_tags(name, numerics=numerics)
 
 
 def tag_person_name(
     name: Name,
     normalize_flags: Normalize = _DEFAULT_FLAGS,
     infer_initials: bool = False,
+    numerics: bool = True,
 ) -> Name:
     """Tag a person Name with name-part + nick + ordinal + initial
     symbols.
@@ -124,6 +139,7 @@ def tag_person_name(
             side where "J Smith" arrives without a GIVEN/MIDDLE tag).
             When False, only parts already tagged as GIVEN/MIDDLE pick
             up INITIAL symbols.
+        numerics: Forwarded to :func:`_infer_part_tags`.
 
     Returns:
         The mutated `name`.
@@ -144,4 +160,4 @@ def tag_person_name(
     for phrase, symbol in matches:
         name.apply_phrase(phrase, symbol)
 
-    return _infer_part_tags(name)
+    return _infer_part_tags(name, numerics=numerics)

--- a/tests/names/test_analyze.py
+++ b/tests/names/test_analyze.py
@@ -29,7 +29,7 @@ def _part_tags(name: Name) -> dict[str, NamePartTag]:
 
 
 def test_person_simple():
-    result = analyze_names(["John Doe"], NameTypeTag.PER)
+    result = analyze_names(NameTypeTag.PER, ["John Doe"])
     name = _only(result)
     assert name.tag == NameTypeTag.PER
     assert name.form == "john doe"
@@ -38,8 +38,8 @@ def test_person_simple():
 
 def test_person_with_part_tags():
     result = analyze_names(
-        ["John Doe"],
         NameTypeTag.PER,
+        ["John Doe"],
         {NamePartTag.GIVEN: ["John"], NamePartTag.FAMILY: ["Doe"]},
     )
     name = _only(result)
@@ -50,8 +50,8 @@ def test_person_with_part_tags():
 
 def test_person_three_tags_slavic():
     result = analyze_names(
-        ["Vladimir Vladimirovitch Putin"],
         NameTypeTag.PER,
+        ["Vladimir Vladimirovitch Putin"],
         {
             NamePartTag.GIVEN: ["Vladimir"],
             NamePartTag.MIDDLE: ["Vladimirovitch"],
@@ -70,8 +70,8 @@ def test_person_multi_token_given():
     # "claude" parts — Name.tag_text tokenises the value and walks the
     # name parts matching the sequence.
     result = analyze_names(
-        ["Jean Claude Juncker"],
         NameTypeTag.PER,
+        ["Jean Claude Juncker"],
         {
             NamePartTag.GIVEN: ["Jean Claude"],
             NamePartTag.FAMILY: ["Juncker"],
@@ -90,9 +90,7 @@ def test_person_multi_token_given():
 def test_company_simple():
     # "Aktiengesellschaft" is the German spelt-out form of "AG" — the
     # org-types table rewrites it to "ag" at compare-form time.
-    result = analyze_names(
-        ["Siemens Aktiengesellschaft"], NameTypeTag.ORG
-    )
+    result = analyze_names(NameTypeTag.ORG, ["Siemens Aktiengesellschaft"])
     name = _only(result)
     assert name.form == "siemens ag"
     assert any(
@@ -105,7 +103,7 @@ def test_entity_upgrade_to_org():
     # ORG_CLASS span whose len(span) (character count) is 3 > 2.
     # _infer_part_tags promotes ENT → ORG on that threshold.
     result = analyze_names(
-        ["Acme Limited Liability Partnership"], NameTypeTag.ENT
+        NameTypeTag.ENT, ["Acme Limited Liability Partnership"]
     )
     name = _only(result)
     assert name.tag == NameTypeTag.ORG
@@ -113,7 +111,7 @@ def test_entity_upgrade_to_org():
 
 def test_entity_no_upgrade():
     # ENT name without any ORG_CLASS span stays ENT.
-    result = analyze_names(["Apollo Missions Archive"], NameTypeTag.ENT)
+    result = analyze_names(NameTypeTag.ENT, ["Apollo Missions Archive"])
     name = _only(result)
     assert name.tag == NameTypeTag.ENT
 
@@ -121,7 +119,7 @@ def test_entity_no_upgrade():
 def test_org_prefix_stripped():
     # "The" is a configured org-prefix; remove_org_prefixes drops it.
     result = analyze_names(
-        ["The Siemens Aktiengesellschaft"], NameTypeTag.ORG
+        NameTypeTag.ORG, ["The Siemens Aktiengesellschaft"]
     )
     name = _only(result)
     assert not name.form.startswith("the ")
@@ -133,7 +131,7 @@ def test_org_prefix_stripped():
 
 
 def test_person_prefix_stripped():
-    result = analyze_names(["Mr. John Smith"], NameTypeTag.PER)
+    result = analyze_names(NameTypeTag.PER, ["Mr. John Smith"])
     name = _only(result)
     assert "mr" not in name.form.split()
     assert "john" in name.form.split()
@@ -146,7 +144,7 @@ def test_person_prefix_stripped():
 def test_infer_initials_query_side():
     # Query-side "J Smith": single-char part gets INITIAL symbol.
     result = analyze_names(
-        ["J Smith"], NameTypeTag.PER, infer_initials=True
+        NameTypeTag.PER, ["J Smith"], infer_initials=True
     )
     name = _only(result)
     initials = {
@@ -159,7 +157,7 @@ def test_infer_initials_off():
     # Without the flag and without a GIVEN/MIDDLE tag on "J",
     # no INITIAL symbol fires.
     result = analyze_names(
-        ["J Smith"], NameTypeTag.PER, infer_initials=False
+        NameTypeTag.PER, ["J Smith"], infer_initials=False
     )
     name = _only(result)
     initials = {
@@ -172,10 +170,11 @@ def test_infer_initials_off():
 
 
 def test_consolidate_drops_substring():
-    # Two input pairs, both should reduce to the longer name only.
+    # Two input pairs, both should reduce to the longer name only
+    # under the default `consolidate=True`.
     # Pair 1: adjacent-shape substring ("John Smith" ⊂ "John R Smith").
     short_long_adjacent = ["John Smith", "John R Smith"]
-    pair1 = analyze_names(short_long_adjacent, NameTypeTag.PER, consolidate=True)
+    pair1 = analyze_names(NameTypeTag.PER, short_long_adjacent)
     assert len(pair1) == 1
     assert _only(pair1).form == "john r smith"
 
@@ -186,14 +185,19 @@ def test_consolidate_drops_substring():
         "Vladimir Putin",
         "Vladimir Vladimirovitch Putin",
     ]
-    pair2 = analyze_names(short_long_slavic, NameTypeTag.PER, consolidate=True)
+    pair2 = analyze_names(NameTypeTag.PER, short_long_slavic)
     assert len(pair2) == 1
     assert _only(pair2).form == "vladimir vladimirovitch putin"
 
-    # Sanity check: without consolidate=True, both names survive.
-    pair1_raw = analyze_names(short_long_adjacent, NameTypeTag.PER)
+    # Opt-out: with consolidate=False both names survive — this is the
+    # indexer-side mode that preserves partial-name recall.
+    pair1_raw = analyze_names(
+        NameTypeTag.PER, short_long_adjacent, consolidate=False
+    )
     assert len(pair1_raw) == 2
-    pair2_raw = analyze_names(short_long_slavic, NameTypeTag.PER)
+    pair2_raw = analyze_names(
+        NameTypeTag.PER, short_long_slavic, consolidate=False
+    )
     assert len(pair2_raw) == 2
 
 
@@ -204,7 +208,7 @@ def test_numerics_on_adds_symbol():
     # A large arbitrary number the AC ordinal list doesn't cover should
     # get a NUMERIC symbol when numerics=True.
     result = analyze_names(
-        ["123456789 Battalion"], NameTypeTag.ORG, numerics=True
+        NameTypeTag.ORG, ["123456789 Battalion"], numerics=True
     )
     name = _only(result)
     numerics = [
@@ -215,7 +219,7 @@ def test_numerics_on_adds_symbol():
 
 def test_numerics_off_tags_but_no_symbol():
     result = analyze_names(
-        ["123456789 Battalion"], NameTypeTag.ORG, numerics=False
+        NameTypeTag.ORG, ["123456789 Battalion"], numerics=False
     )
     name = _only(result)
     # Part still tagged NUM (cheap structural info).
@@ -235,25 +239,25 @@ def test_numerics_off_tags_but_no_symbol():
 
 def test_dedup_by_form():
     # All three casefold to "ibm" — one Name in the result.
-    result = analyze_names(["IBM", "ibm", "Ibm"], NameTypeTag.ORG)
+    result = analyze_names(NameTypeTag.ORG, ["IBM", "ibm", "Ibm"])
     assert len(result) == 1
     assert _only(result).form == "ibm"
 
 
 def test_empty_names():
-    assert analyze_names([], NameTypeTag.PER) == set()
-    assert analyze_names([], NameTypeTag.ORG) == set()
+    assert analyze_names(NameTypeTag.PER, []) == set()
+    assert analyze_names(NameTypeTag.ORG, []) == set()
 
 
 def test_obj_type_tag_no_tagging():
-    result = analyze_names(["Hubble Space Telescope"], NameTypeTag.OBJ)
+    result = analyze_names(NameTypeTag.OBJ, ["Hubble Space Telescope"])
     name = _only(result)
     assert name.tag == NameTypeTag.OBJ
     assert name.symbols == set()
 
 
 def test_unk_type_tag_no_tagging():
-    result = analyze_names(["some mystery string"], NameTypeTag.UNK)
+    result = analyze_names(NameTypeTag.UNK, ["some mystery string"])
     name = _only(result)
     assert name.tag == NameTypeTag.UNK
     assert name.symbols == set()

--- a/tests/names/test_analyze.py
+++ b/tests/names/test_analyze.py
@@ -1,0 +1,259 @@
+"""Tests for rigour.names.analyze.analyze_names.
+
+House style mirrors tests/names/test_tagging.py — one concept per
+test, direct assertions on the returned `Name` objects' `.parts`,
+`.spans`, `.symbols`, `.tag`, `.form`.
+"""
+
+from rigour.names import (
+    Name,
+    NamePartTag,
+    NameTypeTag,
+    Symbol,
+    analyze_names,
+)
+
+
+def _only(names: set[Name]) -> Name:
+    """Extract the single Name from a size-1 result set."""
+    assert len(names) == 1, f"expected 1 Name, got {len(names)}: {names}"
+    return next(iter(names))
+
+
+def _part_tags(name: Name) -> dict[str, NamePartTag]:
+    """Map `part.form` → `part.tag` for convenient assertion."""
+    return {part.form: part.tag for part in name.parts}
+
+
+# --- person names ---
+
+
+def test_person_simple():
+    result = analyze_names(["John Doe"], NameTypeTag.PER)
+    name = _only(result)
+    assert name.tag == NameTypeTag.PER
+    assert name.form == "john doe"
+    assert [part.form for part in name.parts] == ["john", "doe"]
+
+
+def test_person_with_part_tags():
+    result = analyze_names(
+        ["John Doe"],
+        NameTypeTag.PER,
+        {NamePartTag.GIVEN: ["John"], NamePartTag.FAMILY: ["Doe"]},
+    )
+    name = _only(result)
+    tags = _part_tags(name)
+    assert tags["john"] == NamePartTag.GIVEN
+    assert tags["doe"] == NamePartTag.FAMILY
+
+
+def test_person_three_tags_slavic():
+    result = analyze_names(
+        ["Vladimir Vladimirovitch Putin"],
+        NameTypeTag.PER,
+        {
+            NamePartTag.GIVEN: ["Vladimir"],
+            NamePartTag.MIDDLE: ["Vladimirovitch"],
+            NamePartTag.FAMILY: ["Putin"],
+        },
+    )
+    name = _only(result)
+    tags = _part_tags(name)
+    assert tags["vladimir"] == NamePartTag.GIVEN
+    assert tags["vladimirovitch"] == NamePartTag.MIDDLE
+    assert tags["putin"] == NamePartTag.FAMILY
+
+
+def test_person_multi_token_given():
+    # "Jean Claude" as a single GIVEN value should tag BOTH "jean" and
+    # "claude" parts — Name.tag_text tokenises the value and walks the
+    # name parts matching the sequence.
+    result = analyze_names(
+        ["Jean Claude Juncker"],
+        NameTypeTag.PER,
+        {
+            NamePartTag.GIVEN: ["Jean Claude"],
+            NamePartTag.FAMILY: ["Juncker"],
+        },
+    )
+    name = _only(result)
+    tags = _part_tags(name)
+    assert tags["jean"] == NamePartTag.GIVEN
+    assert tags["claude"] == NamePartTag.GIVEN
+    assert tags["juncker"] == NamePartTag.FAMILY
+
+
+# --- org / ENT names ---
+
+
+def test_company_simple():
+    # "Aktiengesellschaft" is the German spelt-out form of "AG" — the
+    # org-types table rewrites it to "ag" at compare-form time.
+    result = analyze_names(
+        ["Siemens Aktiengesellschaft"], NameTypeTag.ORG
+    )
+    name = _only(result)
+    assert name.form == "siemens ag"
+    assert any(
+        sym.category == Symbol.Category.ORG_CLASS for sym in name.symbols
+    )
+
+
+def test_entity_upgrade_to_org():
+    # "Limited Liability Partnership" normalises to "llp" — single
+    # ORG_CLASS span whose len(span) (character count) is 3 > 2.
+    # _infer_part_tags promotes ENT → ORG on that threshold.
+    result = analyze_names(
+        ["Acme Limited Liability Partnership"], NameTypeTag.ENT
+    )
+    name = _only(result)
+    assert name.tag == NameTypeTag.ORG
+
+
+def test_entity_no_upgrade():
+    # ENT name without any ORG_CLASS span stays ENT.
+    result = analyze_names(["Apollo Missions Archive"], NameTypeTag.ENT)
+    name = _only(result)
+    assert name.tag == NameTypeTag.ENT
+
+
+def test_org_prefix_stripped():
+    # "The" is a configured org-prefix; remove_org_prefixes drops it.
+    result = analyze_names(
+        ["The Siemens Aktiengesellschaft"], NameTypeTag.ORG
+    )
+    name = _only(result)
+    assert not name.form.startswith("the ")
+    assert "siemens" in name.form
+    assert "ag" in name.form
+
+
+# --- prefixes ---
+
+
+def test_person_prefix_stripped():
+    result = analyze_names(["Mr. John Smith"], NameTypeTag.PER)
+    name = _only(result)
+    assert "mr" not in name.form.split()
+    assert "john" in name.form.split()
+    assert "smith" in name.form.split()
+
+
+# --- infer_initials ---
+
+
+def test_infer_initials_query_side():
+    # Query-side "J Smith": single-char part gets INITIAL symbol.
+    result = analyze_names(
+        ["J Smith"], NameTypeTag.PER, infer_initials=True
+    )
+    name = _only(result)
+    initials = {
+        sym for sym in name.symbols if sym.category == Symbol.Category.INITIAL
+    }
+    assert Symbol(Symbol.Category.INITIAL, "j") in initials
+
+
+def test_infer_initials_off():
+    # Without the flag and without a GIVEN/MIDDLE tag on "J",
+    # no INITIAL symbol fires.
+    result = analyze_names(
+        ["J Smith"], NameTypeTag.PER, infer_initials=False
+    )
+    name = _only(result)
+    initials = {
+        sym for sym in name.symbols if sym.category == Symbol.Category.INITIAL
+    }
+    assert Symbol(Symbol.Category.INITIAL, "j") not in initials
+
+
+# --- consolidate ---
+
+
+def test_consolidate_drops_substring():
+    # Two input pairs, both should reduce to the longer name only.
+    # Pair 1: adjacent-shape substring ("John Smith" ⊂ "John R Smith").
+    short_long_adjacent = ["John Smith", "John R Smith"]
+    pair1 = analyze_names(short_long_adjacent, NameTypeTag.PER, consolidate=True)
+    assert len(pair1) == 1
+    assert _only(pair1).form == "john r smith"
+
+    # Pair 2: non-adjacent substring with a Slavic patronymic — "Vladimir Putin"
+    # tokens appear in "Vladimir Vladimirovitch Putin" but with a middle
+    # part between them. Name.contains() for PER is adjacency-insensitive.
+    short_long_slavic = [
+        "Vladimir Putin",
+        "Vladimir Vladimirovitch Putin",
+    ]
+    pair2 = analyze_names(short_long_slavic, NameTypeTag.PER, consolidate=True)
+    assert len(pair2) == 1
+    assert _only(pair2).form == "vladimir vladimirovitch putin"
+
+    # Sanity check: without consolidate=True, both names survive.
+    pair1_raw = analyze_names(short_long_adjacent, NameTypeTag.PER)
+    assert len(pair1_raw) == 2
+    pair2_raw = analyze_names(short_long_slavic, NameTypeTag.PER)
+    assert len(pair2_raw) == 2
+
+
+# --- numerics ---
+
+
+def test_numerics_on_adds_symbol():
+    # A large arbitrary number the AC ordinal list doesn't cover should
+    # get a NUMERIC symbol when numerics=True.
+    result = analyze_names(
+        ["123456789 Battalion"], NameTypeTag.ORG, numerics=True
+    )
+    name = _only(result)
+    numerics = [
+        sym for sym in name.symbols if sym.category == Symbol.Category.NUMERIC
+    ]
+    assert Symbol(Symbol.Category.NUMERIC, 123456789) in numerics
+
+
+def test_numerics_off_tags_but_no_symbol():
+    result = analyze_names(
+        ["123456789 Battalion"], NameTypeTag.ORG, numerics=False
+    )
+    name = _only(result)
+    # Part still tagged NUM (cheap structural info).
+    assert any(
+        part.form == "123456789" and part.tag == NamePartTag.NUM
+        for part in name.parts
+    )
+    # But no NUMERIC symbol emitted.
+    numerics = [
+        sym for sym in name.symbols if sym.category == Symbol.Category.NUMERIC
+    ]
+    assert Symbol(Symbol.Category.NUMERIC, 123456789) not in numerics
+
+
+# --- dedup & edge cases ---
+
+
+def test_dedup_by_form():
+    # All three casefold to "ibm" — one Name in the result.
+    result = analyze_names(["IBM", "ibm", "Ibm"], NameTypeTag.ORG)
+    assert len(result) == 1
+    assert _only(result).form == "ibm"
+
+
+def test_empty_names():
+    assert analyze_names([], NameTypeTag.PER) == set()
+    assert analyze_names([], NameTypeTag.ORG) == set()
+
+
+def test_obj_type_tag_no_tagging():
+    result = analyze_names(["Hubble Space Telescope"], NameTypeTag.OBJ)
+    name = _only(result)
+    assert name.tag == NameTypeTag.OBJ
+    assert name.symbols == set()
+
+
+def test_unk_type_tag_no_tagging():
+    result = analyze_names(["some mystery string"], NameTypeTag.UNK)
+    name = _only(result)
+    assert name.tag == NameTypeTag.UNK
+    assert name.symbols == set()


### PR DESCRIPTION
Composes the existing rigour primitives — prenormalize_name, remove_person_prefixes, replace_org_types_compare, remove_org_prefixes, Name construction + tag_text, tag_org_name / tag_person_name, optional consolidate_names — into a single entry point matching the contract in plans/rust-names-parser.md. Phase 5 will collapse the shim into a single FFI call with the same API.

Contract:
- `names: Sequence[str]`, `type_tag: NameTypeTag`, `part_tags: Mapping[NamePartTag, Sequence[str]]` (values may be multi-token strings — Name.tag_text walks the tokens).
- Keyword flags: `infer_initials`, `phonetics`, `numerics`, `consolidate`. `phonetics` is API scaffolding (no-op in the Python shim — NamePart.metaphone is a computed property); meaningful at Rust port time.

Ancillary changes:
- `_infer_part_tags`, `tag_org_name`, `tag_person_name` gain a `numerics: bool = True` parameter so the shim can honour `numerics=False`. Default `True` preserves existing behaviour.
- `plans/rust-names-parser.md` documents the multi-token part-value shape and marks phasing step 1 done.
- `docs/names.md` adds `::: rigour.names.analyze` so mkdocstrings picks up the new module.

Tests: 18 in tests/names/test_analyze.py — person/org/ENT/OBJ/UNK shapes, multi-token part values, infer_initials on/off, consolidate (including Slavic non-adjacent substring), numerics on/off, dedup, prefix stripping, ENT → ORG upgrade.