### PR TITLE
pick: skip representative_names clustering when inputs fit in limit

### DIFF
--- a/rigour/names/pick.py
+++ b/rigour/names/pick.py
@@ -35,21 +35,29 @@ def representative_names(
     limit: int,
     cluster_threshold: float = 0.3,
 ) -> List[str]:
-    """Pick display representatives of the distinct name-clusters in a bag
-    of aliases.
+    """Reduce a bag of aliases to at most `limit` representatives
+    without extreme information loss.
 
-    Useful when a downstream process (e.g. building a search query) wants to
-    probe the alias space broadly with a small number of queries. For a
-    person with 20 transliterations of one name, this returns 1
-    representative; for a person with two genuinely different names (e.g.
-    Nelson Mandela / Rolihlahla Mandela), it returns 2 — because N
-    transliterations of the same name don't add recall, but a second
-    *name* does.
+    Useful when a downstream process (e.g. building a search-index
+    query) wants to probe the alias space broadly under a budget
+    cap. For a person with 20 transliterations of one name and
+    `limit=5`, this returns ~1-5 centroid-selected representatives
+    rather than all 20 near-identical forms. For a person with two
+    genuinely distinct names (Nelson Mandela / Rolihlahla Mandela),
+    both survive — N transliterations of one name don't add recall,
+    but a second *name* does.
 
-    `limit` is a cap, not a quota: if all aliases collapse into one
-    cluster, the result is one name regardless of `limit`. Returned
-    strings are originals from the input (via :func:`pick_name` per
-    cluster), ordered by centroid first, then farthest cluster, etc.
+    **Fast path**: if the input already collapses to `<= limit`
+    distinct names (after casefold-dedup via :func:`reduce_names`),
+    those names are returned as-is without clustering. Compression
+    only runs when the input actually needs to be compressed. This
+    means `cluster_threshold` has no effect when the fast path
+    fires.
+
+    Ordering of the returned list is not guaranteed. Returned
+    strings are originals from the input — :func:`pick_name` per
+    cluster selects the best-case representative when clustering
+    runs.
 
     Args:
         names: input aliases, typically all belonging to one entity.
@@ -57,12 +65,13 @@ def representative_names(
         cluster_threshold: normalized Levenshtein distance (0..1) above
             which two names are considered distinct *names* rather than
             variants of one. Default 0.3 keeps transliterations together
-            while separating genuinely different names.
+            while separating genuinely different names. Ignored when
+            the fast path fires.
     """
     if limit <= 0 or not names:
         return []
     reduced = reduce_names(names)
-    if len(reduced) <= 1:
+    if len(reduced) <= limit:
         return list(reduced)
 
     # Casefolded/whitespace-normalised form of each reduced name, for

--- a/tests/names/test_pick.py
+++ b/tests/names/test_pick.py
@@ -355,10 +355,27 @@ def test_representative_names_returns_originals():
 
 
 def test_representative_names_threshold_tunable():
-    # "John Smith" vs "John Smithey" — lev=3, max_len=12, ratio=0.25.
-    # Tight threshold splits them, loose threshold merges.
-    aliases = ["John Smith", "John Smithey"]
-    tight = representative_names(aliases, 5, cluster_threshold=0.1)
-    loose = representative_names(aliases, 5, cluster_threshold=0.5)
+    # With len(reduced) > limit, clustering runs and the threshold
+    # decides whether the outlier is distinct enough to become a
+    # second seed.
+    aliases = ["John Smith", "John Smithey", "Jonathan Smithey"]
+    # Tight threshold → outlier exceeds threshold, two seeds (loop
+    # exits via the `while len(seeds) < limit` condition).
+    tight = representative_names(aliases, 2, cluster_threshold=0.1)
+    # Loose threshold → outlier swallowed into the one cluster.
+    loose = representative_names(aliases, 2, cluster_threshold=0.9)
     assert len(tight) == 2, tight
     assert len(loose) == 1, loose
+
+
+def test_representative_names_fast_path_returns_reduced():
+    # Fewer distinct names (after reduce_names) than `limit` → the
+    # fast path returns all of them without collapsing similar
+    # spellings into a single centroid. `cluster_threshold` has no
+    # effect here.
+    aliases = ["John Smith", "John Smithey", "Jonathan Smithey"]
+    reps = representative_names(aliases, 10)
+    assert set(reps) == set(aliases), reps
+    # Threshold is ignored when the fast path fires.
+    aggressive = representative_names(aliases, 10, cluster_threshold=0.01)
+    assert set(aggressive) == set(aliases), aggressive


### PR DESCRIPTION
## Summary

`representative_names` was running its clustering machinery (casefold-normalisation, farthest-point seed selection, per-cluster `pick_name`) even when the reduced input already fit the caller's budget — unnecessarily collapsing distinct spelling variants into a single centroid.

For the motivating use case (search-index query generation under a budget cap), spending an available slot on a slightly-different spelling is strictly better than discarding it: the cost is nearly zero, the recall gain is real.

```python
# Before
representative_names(["John", "Jon"], limit=5)  # → ["John"]

# After
representative_names(["John", "Jon"], limit=5)  # → ["John", "Jon"]
```

- Guard changed from `len(reduced) <= 1` to `len(reduced) <= limit`. Clustering only runs when the input genuinely needs compression.
- Docstring updated to describe the fast path and note that `cluster_threshold` is ignored when it fires.
- `test_representative_names_threshold_tunable` adjusted to use 3 aliases with `limit=2` so clustering still runs (2-alias + `limit=5` now hits the fast path, couldn't exercise `cluster_threshold` anymore).
- New `test_representative_names_fast_path_returns_reduced` pins the new behaviour and confirms `cluster_threshold` is a no-op in the fast path.

**No behavioural change** for the motivating large-alias-bag case: 20 Putin transliterations with `limit=5` still clusters and returns ~1-5 centroid-selected reps.

**Coverage**: `rigour/names/pick.py` 95% → 96%. The previously-uncovered `while len(seeds) < limit` natural-exit branch (`87->102` in the old line numbers) is now exercised by the updated threshold test. Remaining partial branches are defensive `Optional[str]` guards after `pick_name` calls — unreachable without mocking.

## Test plan

- [ ] `pytest tests/names/test_pick.py` — 22 tests pass (21 existing + 1 new).
- [ ] `pytest tests/names/test_pick.py --cov=rigour.names.pick` reports 96% on `pick.py`.
- [ ] `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)