### PR TITLE
analyze: wire OBJ prefix strip into rewrite branch

### DIFF
--- a/rigour/names/analyze.py
+++ b/rigour/names/analyze.py
@@ -50,8 +50,9 @@ def analyze_names(
             every name in this batch. Drives which prefix/org-type/
             tagger passes run: `PER` → person prefix strip + person
             tagger; `ORG`/`ENT` → org-type replacement + org prefix
-            strip + org tagger; `OBJ`/`UNK` → no tagging, just
-            construction.
+            strip + org tagger; `OBJ` → object prefix strip ("M/V",
+            "SS", …) but no tagger; `UNK` → no rewrites or tagging,
+            just construction.
         names: Raw name strings as harvested from the source entity.
             Empty strings and inputs that normalise to empty are
             dropped. Duplicates (after prenormalisation) are de-duplicated.

--- a/rust/src/names/analyze.rs
+++ b/rust/src/names/analyze.rs
@@ -7,7 +7,7 @@
 //   1. For PER, if `rewrite`: remove_person_prefixes
 //   2. casefold → form
 //   3. For ORG/ENT, if `rewrite`: replace_org_types_compare +
-//      remove_org_prefixes
+//      remove_org_prefixes; for OBJ, if `rewrite`: remove_obj_prefixes
 //   4. Dedup by form
 //   5. Construct Name + NamePart objects (all eager on construction)
 //   6. Apply part_tags via Name.tag_text for each (tag, values) entry
@@ -33,7 +33,7 @@ use pyo3::types::PySet;
 use crate::names::name::Name;
 use crate::names::org_types;
 use crate::names::part::{NamePart, Span};
-use crate::names::prefix::{remove_org_prefixes, remove_person_prefixes};
+use crate::names::prefix::{remove_obj_prefixes, remove_org_prefixes, remove_person_prefixes};
 use crate::names::symbol::{Symbol, SymbolCategory};
 use crate::names::tag::{INITIAL_TAGS, NamePartTag, NameTypeTag};
 use crate::names::tagger::{TaggerKind, get_tagger};
@@ -99,6 +99,8 @@ pub fn analyze_names(
         if rewrite && matches!(type_tag, NameTypeTag::ORG | NameTypeTag::ENT) {
             form = org_types::replace_compare(&form, Normalize::CASEFOLD, Cleanup::Noop, false);
             form = remove_org_prefixes(&form);
+        } else if rewrite && matches!(type_tag, NameTypeTag::OBJ) {
+            form = remove_obj_prefixes(&form);
         }
         if form.is_empty() || seen.contains(&form) {
             continue;

--- a/tests/names/test_analyze.py
+++ b/tests/names/test_analyze.py
@@ -297,6 +297,20 @@ def test_obj_type_tag_no_tagging():
     assert name.symbols == set()
 
 
+def test_obj_prefix_stripped_when_rewrite():
+    result = analyze_names(NameTypeTag.OBJ, ["M/V Oceanic"])
+    name = _only(result)
+    assert name.original == "M/V Oceanic"
+    assert "m/v" not in name.form
+    assert name.form.endswith("oceanic")
+
+
+def test_obj_prefix_kept_when_rewrite_false():
+    result = analyze_names(NameTypeTag.OBJ, ["M/V Oceanic"], rewrite=False)
+    name = _only(result)
+    assert "m/v" in name.form
+
+
 def test_unk_type_tag_no_tagging():
     result = analyze_names(NameTypeTag.UNK, ["some mystery string"])
     name = _only(result)


### PR DESCRIPTION
## Summary
- A dead-code sweep of `rust/src/` found `remove_obj_prefixes` had no production caller — `analyze_names` had PER and ORG/ENT rewrite branches but no OBJ branch, so the Rust function was only reached by its own unit test.
- Mirror the ORG handling: when `rewrite=True` for `NameTypeTag::OBJ`, strip `"M/V"` / `"SS"` / etc. from `form` only, leaving `Name.original` untouched. The Python-side `rigour/names/prefix.remove_obj_prefixes` continues to work via its own regex against the same wordlist.
- Updated the `analyze_names` Python docstring (OBJ now does prefix strip; UNK still does nothing) and added two tests covering rewrite=True and rewrite=False.

## Test plan
- [x] `pytest tests/names/` — 153 passed
- [x] `cargo clippy --all-targets -- -D warnings` (with and without `--features python`) — clean
- [x] New tests `test_obj_prefix_stripped_when_rewrite` and `test_obj_prefix_kept_when_rewrite_false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)