### PR TITLE
tagger: dedupe (phrase, symbol) pairs in Tagger::tag

### DIFF
--- a/rust/src/names/tagger.rs
+++ b/rust/src/names/tagger.rs
@@ -21,7 +21,7 @@
 // Flag-keyed cache: one compiled Tagger per `(TaggerKind, Normalize)`
 // combination, same shape as the org_types Replacer cache.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock, RwLock};
 
 use serde::Deserialize;
@@ -55,10 +55,20 @@ impl Tagger {
         // recognised phrase as an independent match, not a
         // non-overlapping greedy selection. Same semantic as today's
         // Python tagger calling `ahocorasick-rs` with overlapping=True.
+        //
+        // Dedupe `(phrase, symbol)` here: a token repeated N times in
+        // the haystack fires N AC hits, each iterating the K-symbol
+        // payload, which would emit N×K identical entries. `apply_phrase`
+        // already walks all token-instances per call, so one entry per
+        // pair is what downstream wants. See issue #197.
+        let mut seen: HashSet<(String, Symbol)> = HashSet::new();
         let mut out: Vec<(String, Symbol)> = Vec::new();
         for m in self.needles.find_overlapping(text) {
             for sym in m.payload {
-                out.push((m.matched.to_string(), sym.clone()));
+                let key = (m.matched.to_string(), sym.clone());
+                if seen.insert(key.clone()) {
+                    out.push(key);
+                }
             }
         }
         out
@@ -373,5 +383,22 @@ mod tests {
         let org = get_tagger(TaggerKind::Org, FLAGS);
         let person = get_tagger(TaggerKind::Person, FLAGS);
         assert!(!Arc::ptr_eq(&org, &person));
+    }
+
+    #[test]
+    fn tagger_dedupes_repeated_tokens() {
+        // `bin` occurs twice and carries multiple symbols (SYMBOL:BIN
+        // plus several NAME:Qxxx entries from the person-names corpus).
+        // Without the dedupe in `tag`, the AC iteration would emit
+        // 2 × K identical `(phrase, symbol)` pairs for it.
+        let tagger = get_tagger(TaggerKind::Person, FLAGS);
+        let matches = tagger.tag("isa bin tarif al bin ali");
+        let distinct: HashSet<_> = matches.iter().cloned().collect();
+        assert_eq!(
+            matches.len(),
+            distinct.len(),
+            "tag() must not return duplicate (phrase, symbol) pairs, got {:?}",
+            matches
+        );
     }
 }

--- a/tests/names/test_analyze.py
+++ b/tests/names/test_analyze.py
@@ -614,3 +614,18 @@ def test_raw_org_double_legal_type():
     assert Symbol(Symbol.Category.ORG_CLASS, "JSC") in name.symbols
     assert Symbol(Symbol.Category.ORG_CLASS, "LLC") in name.symbols
     assert len([p for p in name.parts if p.tag == NamePartTag.LEGAL]) == 2
+
+
+def test_repeated_token_no_duplicate_spans():
+    # `bin` occurs twice and carries multiple symbols; without dedupe
+    # in `Tagger::tag`, the AC iteration would produce N²×K spans on
+    # `bin` alone (issue #197). Each span on the same parts with the
+    # same symbol must appear at most once.
+    name = _only(analyze_names(NameTypeTag.PER, ["Isa Bin Tarif Al Bin Ali"]))
+    keys = [
+        (s.symbol.category, s.symbol.id, tuple(id(p) for p in s.parts))
+        for s in name.spans
+    ]
+    assert len(keys) == len(set(keys)), (
+        f"duplicate spans: {len(keys)} total, {len(set(keys))} distinct"
+    )


### PR DESCRIPTION
## Summary
- Dedupe `(phrase, symbol)` entries in `Tagger::tag` with an order-preserving `HashSet` gate. A token repeated N times with K symbols on its AC pattern was yielding N²×K spans on that token (43 spans, 27 distinct on `Isa Bin Tarif Al Bin Ali`), driving a ~75× outlier in `pair_symbols`.
- Adds a Rust unit test (`tagger_dedupes_repeated_tokens`) and a Python integration regression (`test_repeated_token_no_duplicate_spans`).

Closes #197.

## Test plan
- [x] `cargo test` — new test plus existing 5 tagger tests pass
- [x] `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (with and without `--features python`)
- [x] `pytest --cov rigour` (442 passed)
- [x] `mypy --strict rigour`
- [x] Manual repro from the issue: `analyze_names(NameTypeTag.PER, ["Isa Bin Tarif Al Bin Ali"])` now produces 27 spans (was 43), all distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)