### PR TITLE
pair_symbols: dedupe edges sharing (qmask, rmask, category)

### DIFF
--- a/rust/src/names/pairing.rs
+++ b/rust/src/names/pairing.rs
@@ -248,6 +248,34 @@ fn prune_subsumed(edges: &mut Vec<Edge>) {
     });
 }
 
+/// Collapse edges sharing `(qmask, rmask, category)`. Such edges
+/// differ only in `symbol.id` — the DFS coverage dedup at the leaf
+/// keys on `(qmask, rmask, sorted_categories)` and already drops
+/// the redundant ones, but only after walking every selection path
+/// that reaches them. Pre-collapsing here cuts the DFS branching
+/// factor proportionally; on the `Isa Bin Tarif Al Bin Ali` /
+/// `Shaikh …` repro it's 27 → 7 edges, ~7290 → ~32 leaves.
+///
+/// Keeps the alphabetically-smallest `symbol.id` per class as the
+/// canonical edge for deterministic output.
+fn dedupe_equivalent_edges(edges: &mut Vec<Edge>) {
+    if edges.len() < 2 {
+        return;
+    }
+    let mut by_class: HashMap<(u64, u64, SymbolCategory), Edge> = HashMap::new();
+    for edge in edges.drain(..) {
+        let key = (edge.qmask, edge.rmask, edge.symbol.category);
+        let replace = match by_class.get(&key) {
+            Some(existing) => edge.symbol.id < existing.symbol.id,
+            None => true,
+        };
+        if replace {
+            by_class.insert(key, edge);
+        }
+    }
+    edges.extend(by_class.into_values());
+}
+
 /// Deterministic sort key: earlier-in-name edges first, ties
 /// broken by category and symbol id.
 fn edge_sort_key(e: &Edge) -> (u32, u32, SymbolCategory, Arc<str>) {
@@ -410,6 +438,7 @@ pub fn py_pair_symbols(
 
     let mut edges = build_candidate_edges(&q_spans, &r_spans);
     prune_subsumed(&mut edges);
+    dedupe_equivalent_edges(&mut edges);
     edges.sort_by_cached_key(edge_sort_key);
 
     let coverings = enumerate_coverings(&edges);
@@ -614,6 +643,45 @@ mod tests {
         ];
         prune_subsumed(&mut edges);
         assert_eq!(edges.len(), 2, "cross-category edge must survive");
+    }
+
+    #[test]
+    fn dedupe_collapses_same_qrcat_keeps_smallest_id() {
+        // Three edges sharing (qmask, rmask, NAME) and one cross-class
+        // edge. Only the alphabetically-smallest id survives in the
+        // NAME class; the cross-class edge is left alone.
+        let mut edges = vec![
+            mk_edge(1 << 0, 1 << 0, sym(SymbolCategory::NAME, "Q3")),
+            mk_edge(1 << 0, 1 << 0, sym(SymbolCategory::NAME, "Q1")),
+            mk_edge(1 << 0, 1 << 0, sym(SymbolCategory::NAME, "Q2")),
+            mk_edge(1 << 0, 1 << 0, sym(SymbolCategory::SYMBOL, "FOO")),
+        ];
+        dedupe_equivalent_edges(&mut edges);
+        assert_eq!(edges.len(), 2);
+        let kept: HashSet<(SymbolCategory, String)> = edges
+            .iter()
+            .map(|e| (e.symbol.category, e.symbol.id.to_string()))
+            .collect();
+        let expected: HashSet<(SymbolCategory, String)> = [
+            (SymbolCategory::NAME, "Q1".to_string()),
+            (SymbolCategory::SYMBOL, "FOO".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(kept, expected);
+    }
+
+    #[test]
+    fn dedupe_preserves_distinct_masks() {
+        // Same category, same id, but different qmasks → distinct
+        // edges (each binds a different q-instance to its r-counterpart).
+        let s = sym(SymbolCategory::NAME, "QBin");
+        let mut edges = vec![
+            mk_edge(1 << 1, 1 << 2, s.clone()),
+            mk_edge(1 << 4, 1 << 5, s.clone()),
+        ];
+        dedupe_equivalent_edges(&mut edges);
+        assert_eq!(edges.len(), 2, "distinct masks must not collapse");
     }
 
     #[test]

--- a/tests/names/test_symbol.py
+++ b/tests/names/test_symbol.py
@@ -373,3 +373,34 @@ def test_too_many_parts_refuses_pairing():
     r = _only(analyze_names(NameTypeTag.PER, [long_name]))
     assert len(q.parts) == 70
     assert pair_shape(pair_symbols(q, r)) == [[]]
+
+
+def test_repeated_token_pairings_collapsed():  # corpus-dependent
+    # Repeated tokens carrying overlapping symbol coverage used to
+    # explode the DFS — `bin` appearing twice with ~8 NAME symbols
+    # produced 27 candidate edges across only 7 distinct
+    # (qmask, rmask, category) classes, driving the search to
+    # ~7290 leaves (issue #198). Edge-level dedup collapses them
+    # before DFS; the user-visible pairings are still exactly the
+    # category multiset choices on each token.
+    q = _only(analyze_names(NameTypeTag.PER, ["Isa Bin Tarif Al Bin Ali"]))
+    r = _only(analyze_names(NameTypeTag.PER, ["Shaikh Isa Bin Tarif Al Bin Ali"]))
+    shape = sorted(pair_shape(pair_symbols(q, r)))
+    # Three pairings, distinguished by NAME-vs-SYMBOL choice on the
+    # two `bin` instances: NAME+NAME, NAME+SYMBOL, SYMBOL+SYMBOL.
+    assert len(shape) == 3
+    bin_categories = [
+        sorted(cat for q_text, _, cat in pairing if q_text == "bin")
+        for pairing in shape
+    ]
+    assert bin_categories == [
+        ["NAME", "NAME"],
+        ["NAME", "SYMBOL"],
+        ["SYMBOL", "SYMBOL"],
+    ]
+    # Every pairing covers the four corpus-known query tokens
+    # (`tarif` isn't in the person-names corpus, so no edge fires
+    # on it) — no covered token is dropped after dedup.
+    for pairing in shape:
+        q_tokens = {q_text for q_text, _, _ in pairing}
+        assert q_tokens == {"isa", "bin", "al", "ali"}


### PR DESCRIPTION
## Summary

Closes #198. The post-#197 residual on `Isa Bin Tarif Al Bin Ali` (~402 µs vs ~25 µs median) wasn't coming from where the issue described. `build_candidate_edges` already collapses `N × M` instance bindings to `min(N, M)` per symbol via greedy widest-first binding — only 27 edges survive (not 139). But those 27 collapse to **just 7 distinct `(qmask, rmask, category)` classes**: each `bin` instance carries 8 NAME symbols with different ids on the same `(qmask, rmask)` pair, all of which the DFS leaf-dedup eventually collapses on `(qmask, rmask, sorted_categories)` anyway — after exploring 7290 leaves to keep 3 pairings.

Fix: pre-collapse equivalent edges in a new `dedupe_equivalent_edges` step between `prune_subsumed` and the sort. Keep the alphabetically-smallest `symbol.id` per class as canonical for deterministic output.

### Measurements

Best-of-5, 2000 iters, raw `_pair_symbols`:

| Case | q/r spans | Pairings | Before | After |
|---|---|---:|---:|---:|
| Repro (`Isa Bin Tarif Al Bin Ali` vs `Shaikh …`) | 27 / 29 | 3 | **402 µs** | **13.5 µs** (~30×) |
| `Vladimir Putin` vs `Vladimir Vladimirovich Putin` | 3 / 4 | 1 | 1.8 µs | 1.9 µs |
| `John Smith` vs `John Smith` | 5 / 5 | 2 | 2.9 µs | 2.9 µs |

Output is bit-for-bit identical on the existing test corpus — the DFS was already collapsing these classes at the leaf, we just stop the search reaching them.

### Behavior note

For inputs where multiple equivalent edges differ only in `symbol.id`, the canonical id picked may shift (today: incidentally last by sort key via skip-first DFS; now: smallest id, deterministic). Existing tests assert on `(query_text, result_text, category)` shape, not specific ids, and pass unchanged. The `(q, r, category)` shape downstream consumers care about is invariant.

## Test plan
- [x] `cargo test --features python pairing` — 15 passed (added 2 dedup tests)
- [x] `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (with and without `--features python`)
- [x] `pytest --cov rigour` — 443 passed (added `test_repeated_token_pairings_collapsed`)
- [x] `mypy --strict rigour`
- [x] Manual perf check via temporary instrumented build: pre/post numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)