### PR TITLE
names: anchor STOP parts in tag_sort to preserve positional info

### DIFF
--- a/rust/src/names/part.rs
+++ b/rust/src/names/part.rs
@@ -238,7 +238,13 @@ impl NamePart {
 /// Rust-callable version of [`NamePart::tag_sort`]. Shared by the
 /// classmethod and by [`crate::names::alignment`]'s fallback path.
 ///
-/// **Stable**: parts with the same tag preserve their input order.
+/// **Stable**: parts with the same tag-order key preserve their
+/// input order. Note that STOP collapses onto UNSET's order key
+/// (see [`NamePartTag::order_index`]) — particles like Dutch
+/// `der` carry positional information that downstream alignment
+/// depends on, so they sort with their neighbours rather than
+/// being herded to the end of the sequence.
+///
 /// Relied on by the alignment fallback path, which depends on the
 /// output being deterministic for a given input sequence.
 pub fn tag_sort_parts(py: Python<'_>, parts: Vec<Py<NamePart>>) -> Vec<Py<NamePart>> {

--- a/rust/src/names/tag.rs
+++ b/rust/src/names/tag.rs
@@ -202,10 +202,21 @@ impl NamePartTag {
     /// Position in [`NAME_TAGS_ORDER`] — used as the sort key in
     /// [`crate::names::part::NamePart::tag_sort`]. Infallible; every
     /// variant is in the order array.
+    ///
+    /// STOP collapses onto UNSET's index. Stopword-tagged particles
+    /// (Dutch `der`, English `of`, …) carry positional information
+    /// for downstream alignment — sorting them to the end would
+    /// break token-merge cases like `van der bilt` ↔ `vanderbilt`.
+    /// Treating them as positionally neutral keeps them in their
+    /// input position relative to surrounding UNSET tokens.
     pub fn order_index(&self) -> usize {
+        let key = match self {
+            NamePartTag::STOP => &NamePartTag::UNSET,
+            other => other,
+        };
         NAME_TAGS_ORDER
             .iter()
-            .position(|t| t == self)
+            .position(|t| t == key)
             .expect("every NamePartTag variant is in NAME_TAGS_ORDER")
     }
 

--- a/tests/names/test_part.py
+++ b/tests/names/test_part.py
@@ -129,3 +129,35 @@ def test_name_part_sort_stable():
     assert sorted_parts[0].form == "x"
     assert sorted_parts[1].form == "c"
     assert sorted_parts[2].form == "a"
+
+
+def test_name_part_sort_stop_anchored():
+    # STOP-tagged parts (Dutch tussenvoegsels and similar particles)
+    # must keep their original index — they carry positional info
+    # that downstream alignment relies on. Tag-sorting them to the
+    # end would break token-merge cases like
+    # `vanderbilt` ↔ `[van, der, bilt]`.
+    van = NamePart("van", 0, NamePartTag.UNSET)
+    der = NamePart("der", 1, NamePartTag.STOP)
+    bilt = NamePart("bilt", 2, NamePartTag.UNSET)
+    assert NamePart.tag_sort([van, der, bilt]) == [van, der, bilt]
+
+
+def test_name_part_sort_stop_with_non_stop_reordering():
+    # Non-STOP parts get sorted around the STOP anchors. STOP stays
+    # where it was; the non-STOP slots get filled with the
+    # tag-order-sorted remainder.
+    family = NamePart("family", 0, NamePartTag.FAMILY)
+    der = NamePart("der", 1, NamePartTag.STOP)
+    given = NamePart("given", 2, NamePartTag.GIVEN)
+    # GIVEN sorts before FAMILY; STOP stays in the middle slot.
+    assert NamePart.tag_sort([family, der, given]) == [given, der, family]
+
+
+def test_name_part_sort_only_stops():
+    # Edge case: a sequence of only-STOP parts should round-trip
+    # unchanged (no non-STOPs to interleave around).
+    of = NamePart("of", 0, NamePartTag.STOP)
+    the = NamePart("the", 1, NamePartTag.STOP)
+    assert NamePart.tag_sort([of, the]) == [of, the]
+    assert NamePart.tag_sort([the, of]) == [the, of]


### PR DESCRIPTION
## Summary

Stop tag-sorting STOP-tagged parts to the end of the sequence. They get `UNSET`'s order index, which leaves them in their input position relative to surrounding tokens — sorting them to the end was breaking token-merge alignment downstream.

## What this fixes

`vanderbilt` ↔ `van der bilt` (the canonical token-merge case): the Dutch tussenvoegsel `der` is tagged STOP by `analyze_names`. The pre-fix `tag_sort` reorders the residue from `[van, der, bilt]` to `[van, bilt, der]`. The monotone DP in `compare_parts` can no longer thread `vanderbilt` through `van...bilt` once `der` has been pushed to the end — it ends up deleting `der` off the qry side (cost 3.0), busting the per-side budget cap (~2.4 for a 10-char token), and the cluster scores **0**. Net: a STRONG-tier token-merge case that the rigour-level `test_token_merge_is_cheap` test passes scores **0.219** at the full-matcher level.

The bug isn't in `compare_parts` (which works correctly on the natural-order input) or in clustering — it's `tag_sort`'s reordering destroying positional information that the alignment DP relies on.

## How

One-line change in `NamePartTag::order_index`: STOP returns `UNSET`'s position. Stable sort then leaves STOPs in their input order relative to surrounding UNSET tokens; non-UNSET tags slot around them by index. Treats STOP as positionally neutral rather than herding it to the end.

Display-ordering implication: STOP parts now render alongside their UNSET neighbours rather than at the end. In practice STOP parts (Dutch tussenvoegsels, English particles like `of`) sit between meaningful tokens in real names, so this matches expected display order.

## Tests

3 new tests in `tests/names/test_part.py`:

| Test | What it asserts |
|---|---|
| `stop_anchored` | `[van(UNSET), der(STOP), bilt(UNSET)]` round-trips through `tag_sort` unchanged. Direct regression for the motivating case. |
| `stop_with_non_stop_reordering` | `[family(FAMILY), der(STOP), given(GIVEN)]` → `[given, der, family]` — STOP stays mid-sequence while non-STOPs sort around it. |
| `only_stops` | Sequence of only-STOP parts round-trips both directions. Edge case. |

Existing 6 `test_part.py` tests pass unchanged — none touch STOP.

## Validation

`nomenklatura/contrib/name_bench/cases.csv` (818 cases) on `pudo/rigour-compare`:

| Metric | Before | After |
|---|---|---|
| Overall F1 | 0.795 | 0.796 |
| STRONG-tier F1 | 1.000 | 1.000 |
| synth_companies F1 | 0.854 | 0.858 |
| Outcome flips | — | 1 (improvement, 0 regressions) |

The single flip: `Bank of Armenia Corporation` ↔ `Bank of America Corporation` previously scored 0.838 (incorrectly FP), now scores 0.630 (correctly TN). With `of` anchored between `Bank` and `Armenia`/`America`, the alignment cleanly distinguishes `Armenia` from `America` rather than letting `of`'s relocation mush the two together. Two minor score adjustments don't flip outcomes (`Bank of Chima Limited`/`Bank of China Limited`: 0.901→0.884 stays TP; `Bowne of New York City, L.L.C.`/`Bowne of Los Angeles, Inc.`: 0.348→0.468 stays TN).

`cases-align.csv` (alignment-fragility fixture file): STRONG-tier 0.800 → 1.000, overall F1 0.667 → 0.800. Vanderbilt becomes a TP.

## Test plan

- [x] `cargo test --release --features python` — 215 pass
- [x] `pytest tests/` — 473 pass (3 new in `test_part.py`)
- [x] `mypy --strict rigour` — clean across 68 files
- [x] `cargo clippy --all-targets -- -D warnings` (with and without `--features python`) — clean
- [x] `cargo fmt --check` — clean
- [x] `cases.csv` validation — 1 improvement, 0 regressions, F1 +0.001, STRONG-tier preserved at 1.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)