### PR TITLE
names: collapse X-bridge docs to a one-line note

### DIFF
--- a/plans/arch-name-distance.md
+++ b/plans/arch-name-distance.md
@@ -258,33 +258,12 @@ binding all three result parts) and chain-shaped patterns cleanly:
 each new edge shares a vertex with the existing cluster, so they
 fold into one record instead of three near-misses.
 
-**X-bridge limitation.** The clusterer does *not* merge two
-already-existing clusters when a later edge bridges them with both
-sides newly present in different clusters
-(`(q0, r0)` → cluster A, `(q1, r1)` → cluster B, then `(q0, r1)` or
-`(q1, r0)` arrives but neither matches a fresh side). In that case,
-the bridging edge joins one of the two clusters and the other
-remains separate, leaving a part referenced from both clusters. This
-is rare in practice (the 0.51-overlap rule keeps most parts to a
-single dominant counterpart) but it's a real invariant violation
-that the current downstream scoring tolerates because the duplicated
-part contributes the same cost stream to both clusters. A
-union-find rewrite is part of the open clustering work.
-
-Two related fragility points around the 0.51 threshold:
-
-- When the alignment produces N+1 vs N equal-char steps between two
-  parts, the cluster either forms (paired-but-zero-score record,
-  weight 1.0) or doesn't (two solo records with extra-name weights).
-  The two outcomes drag the orchestration aggregate down by
-  different amounts even though the underlying string similarity is
-  comparable.
-- Replacing the threshold with alignment-connectivity (≥1 equal-char
-  step connects two parts) is the spec direction; iteration is
-  open.
-
-Tracked in `weighted-distance.md` § Open spec knobs and § Magic-
-number systematisation.
+The 0.51 threshold is fragile near the cliff (a paired-but-zero-score
+cluster vs. two solos drag the orchestration aggregate down by
+different amounts even when underlying similarity is comparable);
+replacing it with alignment-connectivity (≥1 equal-char step) plus a
+part-id DSU clusterer is the natural follow-up — tracked in
+`weighted-distance.md` § Open spec knobs.
 
 ## Per-cluster score
 

--- a/plans/weighted-distance.md
+++ b/plans/weighted-distance.md
@@ -146,26 +146,7 @@ plus a harness re-run away from a number.
   harness-driven. See [issue #202](https://github.com/opensanctions/rigour/issues/202)
   for the Bashar-class particle case (extending the existing 0.7
   weight to fire when *either* side is a stopword).
-- **Clustering rule fragility.** Two related issues:
-  - The 0.51-overlap rule is sensitive to alignment-shape changes —
-    a paired-but-zero-score cluster vs. two solos with extra-name
-    weights drag the orchestration aggregate down by different
-    amounts even when underlying similarity is comparable. The
-    phase-3 BAE Systems / BAE Industries case is a concrete
-    example. Replacing the threshold with alignment-connectivity
-    (≥1 equal-char step) per the spec's pairing rule should make
-    this less fragile.
-  - The current clusterer joins a new `(qp, rp)` edge to whichever
-    existing cluster already contains either side, but does not
-    merge two existing clusters when a later edge bridges them
-    (X-bridge). A part can end up referenced from two clusters in
-    that case — rare under the 0.51 threshold (most parts have a
-    single dominant counterpart) but a real invariant violation.
-    The cost-stream layout means the duplicated part contributes
-    its costs to both downstream cluster scores; downstream
-    averaging tolerates it but it's not what the docstring promises.
-    A union-find / DSU rewrite is the fix; landing it together with
-    the connectivity-based pairing rule above is the natural shape.
+- **Clustering rule fragility.** The 0.51-overlap rule is fragile near the cliff (paired-but-zero-score cluster vs. two solos with extra-name weights drag the orchestration aggregate down by different amounts), and replacing it with alignment-connectivity (≥1 equal-char step) plus a part-id DSU clusterer is the natural follow-up — the BAE Systems / BAE Industries case is the worked example.
 
 ### Magic-number systematisation
 

--- a/rust/src/names/compare.rs
+++ b/rust/src/names/compare.rs
@@ -529,14 +529,16 @@ struct Cluster {
 /// and chain-shaped patterns (`q0`↔`r0`, `q0`↔`r1`, `q1`↔`r1`)
 /// cleanly: each new edge shares a vertex with the growing cluster.
 ///
-/// **X-bridge limitation.** Two already-existing clusters are not
-/// merged when a later edge bridges them — the bridging edge joins
-/// one and the other remains separate, leaving a part referenced
-/// from both. Rare in practice (the 0.51 threshold keeps most parts
-/// to a single dominant counterpart) but a real invariant
-/// violation; tracked in `plans/weighted-distance.md` § Open spec
-/// knobs as part of the clustering-rule fragility item, alongside
-/// the alignment-connectivity replacement for the threshold.
+/// The shared-vertex merge would mishandle an "X-bridge" where two
+/// already-existing clusters get connected by a later edge that
+/// shares no vertex with either's original. That case is
+/// structurally unreachable here: `align.overlaps` is built by a
+/// monotone DP walk, so its keys form a non-decreasing path in
+/// `(qp, rp)`-space and can't contain the cross pattern an X-bridge
+/// requires. If the DP ever stops being monotone — or the threshold
+/// drops to admit many more edges per the connectivity-rule
+/// proposal in `plans/weighted-distance.md` — replace the loop with
+/// a part-id DSU.
 ///
 /// Parts that no overlap pair clears the threshold for surface as
 /// solo clusters at the end.


### PR DESCRIPTION
## Summary

The X-bridge case in `run_cluster` (a part referenced from two clusters when a later edge bridges two pre-existing clusters with no shared vertex) is structurally unreachable under the current monotone DP. The cursor walk in `run_align` can't produce the non-monotone overlap pattern an X-bridge requires. Confirmed empirically: 0 bridge events fired across the 818-case cases.csv corpus.

The plan docs and the `run_cluster` docstring previously framed it as a real-but-rare invariant violation that needed a union-find rewrite. After investigation that's misleading — the bug is real algorithmically but unreachable from real input today. This PR collapses the discussion to a one-line note in each of the three places it was tracked.

## Background

Investigation triggered by a `pudo/cluster-dsu` branch (kept locally as a reference) that would have been a ~300-line rewrite — Dsu struct + iterative path-compressed `find` + union-by-rank + emit-order tick tracking + 6 unit tests. The rewrite is correct algorithmically and bit-identical on the corpus (0 outcome flips, 0 score diffs over 818 cases). But the X-bridge regression test it introduces exercises code that the real DP can never trigger — it builds synthetic `AlignmentData` directly.

The structural argument: `align.overlaps` is built by a single monotone DP walk through the SEP-joined strings. Both `qry_idx` and `res_idx` only advance, never backtrack. So if `(qp_a, rp_b)` accumulates an Equal step, no later step can be at `(qp_c, rp_d)` with `qp_c > qp_a` and `rp_d < rp_b` — but that's exactly what an X-bridge needs (two non-vertex-sharing edges, then a third that bridges them). Under sort-order processing on lex-sorted edges, the bridge edge always lands at a position where it's a chain-via-shared-vertex instead.

The DSU rewrite is the right shape if the connectivity-rule replacement lands (threshold = 0 expands which edges qualify and could unlock the case), or if the DP ever stops being monotone. Neither is imminent. Better to revert and pull the DSU back when there's a concrete reason.

## What this PR changes

| File | Change |
|---|---|
| `rust/src/names/compare.rs` (`run_cluster` docstring) | Replaces the "X-bridge limitation" paragraph with a short note explaining structural unreachability + what would need to change to unlock it. |
| `plans/weighted-distance.md` § Open spec knobs → Clustering rule fragility | Two sub-bullets collapsed to one sentence covering both threshold fragility and the DSU follow-up. |
| `plans/arch-name-distance.md` § Pairing rule | Drops the X-bridge limitation paragraph + redundant fragility bullets; keeps the threshold-fragility one-liner. |

Net diff: 17 insertions, 55 deletions.

No code behaviour change. No test changes.

## Test plan

- [x] `cargo test --release --features python` — clean
- [x] `pytest tests/` — 470 pass
- [x] `mypy --strict rigour` — clean
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (with and without `--features python`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)