### PR TITLE
chore: drop rust-data target, use make build everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,10 @@ iso639.py` (ISO-639 tables for `rigour.langs`) and
 Treat them the same as any Python source — not a pattern to
 replicate for new data.
 
-`make rust-data` regenerates everything under `rust/data/` from
-`resources/`. CI runs it and fails on diff, so after editing anything
-under `resources/` you need to run `make rust-data` and commit the
-regenerated artifacts.
+`make build` regenerates everything under `rust/data/` (and the
+remaining Python data tables) from `resources/`. CI runs it and
+fails on diff, so after editing anything under `resources/` you
+need to run `make build` and commit the regenerated artifacts.
 
 ### Dev workflow for Rust-touching changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs build typecheck test develop develop-debug rust-test rust-fmt rust-fmt-check bench rust-data build-iso639 build-territories build-addresses build-names
+.PHONY: docs build typecheck test develop develop-debug rust-test rust-fmt rust-fmt-check bench build-iso639 build-territories build-addresses build-names build-text
 
 check: build typecheck test
 
@@ -53,13 +53,14 @@ build-names:
 build-text:
 	python genscripts/generate_text.py
 
+# Regenerate every data artifact in the repo, both Rust-consumed
+# (under rust/data and rust/src/generated, from the names / text /
+# territories / addresses generators) and Python-consumed (the
+# iso639 and addresses tables that haven't been ported to Rust yet).
+# Generators are dual-emit, so running build keeps Rust + Python
+# tables in lockstep. CI calls this + git-diffs rust/data and
+# rust/src/generated to catch stale checkins.
 build: build-iso639 build-territories build-addresses build-names build-text
-
-# Regenerate Rust-consumed data artifacts (under rust/data and
-# rust/src/generated). Generators are dual-emit — running them produces the
-# Rust artifacts alongside the existing Python ones, which keeps the two
-# from drifting. CI calls this + git-diffs to catch stale checkins.
-rust-data: build-names build-text build-territories
 
 docs:
 	mkdocs build -c -d site

--- a/plans/arch-name-distance.md
+++ b/plans/arch-name-distance.md
@@ -203,7 +203,7 @@ Notes:
 Visual / phonetic confusable pairs live in `resources/names/compare.yml`
 (committed YAML). The genscript emits `rust/data/names/compare.json`
 with both directions pre-expanded so the lookup is a single hash probe.
-Editing the table is one YAML edit + `make rust-data`.
+Editing the table is one YAML edit + `make build`.
 
 The remaining scalars (`COST_*`, `BUDGET_LOG_BASE`, `BUDGET_SHORT_FLOOR`,
 `CLUSTER_OVERLAP_MIN`) live as named constants at the top of

--- a/plans/arch-rust-core.md
+++ b/plans/arch-rust-core.md
@@ -201,7 +201,7 @@ human-inspectable when a regeneration looks wrong. `serde` /
 The generators use the broader Python ecosystem (Wikidata client,
 `unidecode`, existing rigour utilities), run rarely, and would
 double in size to rewrite. The clean split is **Python generates,
-Rust consumes.** `make rust-data` regenerates everything under
+Rust consumes.** `make build` regenerates everything under
 `rust/data/` + `rust/src/generated/`; CI runs it and `git diff`s
 against the committed artifacts as the contract.
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -44,14 +44,14 @@ const FILES: &[Compress] = &[
         dst: "symbols.json.zst",
         missing: "rust/data/names/symbols.json not found — \
                   compiling empty symbols blob. Run \
-                  `make rust-data` to regenerate.",
+                  `make build-names` to regenerate.",
     },
     Compress {
         src: "data/names/org_types.json",
         dst: "org_types.json.zst",
         missing: "rust/data/names/org_types.json not found — \
                   compiling empty org-types blob. Run \
-                  `make rust-data` to regenerate.",
+                  `make build-names` to regenerate.",
     },
 ];
 


### PR DESCRIPTION
## Summary

`rust-data` was a Makefile target covering 3 of the 5 data generators (names, text, territories — the ones that emit `rust/data/` artifacts); `build` covers all 5 (adds iso639 and addresses, the two remaining Python-only data modules whose Rust ports haven't happened yet).

The two-target split bought a few seconds in CI by skipping iso639 and addresses regen on the data-drift check. Practically: CI already calls `make build` (since at least the merged compare_parts mega-PR), so `rust-data` was unused in CI and only existed as a local-dev shortcut. The cognitive cost of "which one do I run" outweighed the trivial CI saving.

Collapsing to one canonical entry point. When iso639 and addresses eventually get ported to Rust, `build` picks up the new generators without further Makefile churn.

## What changed

- `Makefile`: drop the `rust-data` target + its `.PHONY` entry. Fold its comment into `build`'s docstring (now the canonical "regenerate every data artifact" entry point).
- `CLAUDE.md`: `make rust-data` → `make build` in the regenerate-after-resource-edit instruction.
- `rust/build.rs`: error messages that suggested `make rust-data` now point at the specific generator that produces the missing artifact (`make build-names`) — more actionable since the error is artifact-scoped.
- `plans/arch-name-distance.md`, `plans/arch-rust-core.md`: prose references updated.
- `.github/workflows/build.yml`: no changes needed — already calls `make build`.

## Test plan

- [x] `grep -rn rust-data` clean across the repo
- [x] `make build` runs end-to-end with no errors
- [x] `git diff --exit-code rust/data rust/src/generated` after `make build` — no drift (generators produce the same artifacts that are already committed, validating that `build` covers what `rust-data` did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)