### PR TITLE
ids: zero-pad short IMO numbers before checksum

### DIFF
--- a/rigour/ids/imo.py
+++ b/rigour/ids/imo.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from rigour.ids.common import IdentifierFormat
 
-IMO_RE = re.compile(r"\b(IMO)?(\d{7})\b")
+IMO_RE = re.compile(r"\b(IMO)?(\d{1,7})\b")
 
 
 class IMO(IdentifierFormat):
@@ -15,11 +15,16 @@ class IMO(IdentifierFormat):
 
     @classmethod
     def is_valid(cls, text: str) -> bool:
-        """Determine if the given string is a valid IMO number."""
+        """Determine if the given string is a valid IMO number.
+
+        Shorter numeric strings are left-padded with zeros to seven digits
+        before the checksum is verified, since data sources commonly strip
+        leading zeros from IMO fields.
+        """
         match = IMO_RE.search(text)
         if match is None:
             return False
-        value = match.group(2)
+        value = match.group(2).zfill(7)
         digits = [int(d) for d in value]
 
         # Check if it's a vessel IMO number:
@@ -38,11 +43,11 @@ class IMO(IdentifierFormat):
 
     @classmethod
     def normalize(cls, text: str) -> Optional[str]:
-        """Normalize the given string to a valid NPI."""
+        """Normalize the given string to a valid IMO number."""
         match = IMO_RE.search(text)
         if match is None:
             return None
-        value = match.group(2)
+        value = match.group(2).zfill(7)
         if cls.is_valid(value):
             return f"IMO{value}"
         return None

--- a/tests/ids/test_imo.py
+++ b/tests/ids/test_imo.py
@@ -6,7 +6,6 @@ def test_ship_imo():
     assert IMO.normalize("IMO9126819") == "IMO9126819"
     assert IMO.normalize("9126819") == "IMO9126819"
     assert IMO.normalize("91268191") is None
-    assert IMO.normalize("IMO 912681") is None
     assert IMO.is_valid("IMO 9126819")
     assert IMO.is_valid("9126819")
     assert not IMO.is_valid("IMO 9126")
@@ -15,6 +14,16 @@ def test_ship_imo():
     assert IMO.format("9126819") == "IMO9126819"
     assert IMO.format("IMO9126819") == "IMO9126819"
     assert IMO.normalize("IMO number: 9126819") == "IMO9126819"
+
+
+def test_imo_leading_zero_stripped():
+    # Sources sometimes strip leading zeros — pad back to 7 before checksum.
+    assert IMO.normalize("912681") == "IMO0912681"
+    assert IMO.normalize("IMO 912681") == "IMO0912681"
+    assert IMO.is_valid("912681")
+    # Padding should not turn an unrelated short number into a valid IMO.
+    assert not IMO.is_valid("9126")
+    assert IMO.normalize("9126") is None
 
 
 def test_org_imo():


### PR DESCRIPTION
## Summary
- Data sources commonly strip leading zeros from IMO fields, so values like `912681` were being rejected even though they represent valid IMO `0912681`.
- The IMO regex now accepts 1–7 digits; `is_valid` / `normalize` left-pad to seven digits with `zfill(7)` before running the vessel and company checksums.
- Also fixed a stale "valid NPI" docstring on `IMO.normalize` that was copied from the NPI format.

## Test plan
- [x] `pytest tests/ids/test_imo.py` — existing assertions plus new `test_imo_leading_zero_stripped` covering `912681` → `IMO0912681` and confirming arbitrary short numbers (`9126`) still fail the checksum.
- [x] `pytest tests/ids/` — full IDs suite green (101 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)