### PR TITLE
ci: embed Rust dep graph in wheels + add SLSA build provenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           manylinux: auto
           sccache: "true"
           before-script-linux: |
-            cargo install cargo-auditable --locked
+            RUSTC_WRAPPER= cargo install cargo-auditable --locked
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:
@@ -108,7 +108,7 @@ jobs:
           manylinux: musllinux_1_2
           sccache: "true"
           before-script-linux: |
-            cargo install cargo-auditable --locked
+            RUSTC_WRAPPER= cargo install cargo-auditable --locked
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,19 @@ jobs:
       - uses: actions/checkout@v6
       - uses: PyO3/maturin-action@v1
         env:
-          CARGO: cargo-auditable
+          CARGO: /usr/local/bin/cargo-auditable-wrapper
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           sccache: "true"
           before-script-linux: |
             RUSTC_WRAPPER= cargo install cargo-auditable --locked
+            REAL_CARGO=$(command -v cargo)
+            cat > /usr/local/bin/cargo-auditable-wrapper <<EOF
+            #!/bin/sh
+            exec "$REAL_CARGO" auditable "\$@"
+            EOF
+            chmod +x /usr/local/bin/cargo-auditable-wrapper
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:
@@ -102,13 +108,19 @@ jobs:
       - uses: actions/checkout@v6
       - uses: PyO3/maturin-action@v1
         env:
-          CARGO: cargo-auditable
+          CARGO: /usr/local/bin/cargo-auditable-wrapper
         with:
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           sccache: "true"
           before-script-linux: |
             RUSTC_WRAPPER= cargo install cargo-auditable --locked
+            REAL_CARGO=$(command -v cargo)
+            cat > /usr/local/bin/cargo-auditable-wrapper <<EOF
+            #!/bin/sh
+            exec "$REAL_CARGO" auditable "\$@"
+            EOF
+            chmod +x /usr/local/bin/cargo-auditable-wrapper
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:
@@ -134,9 +146,17 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-auditable
+      - name: Create cargo-auditable wrapper for maturin
+        run: |
+          REAL_CARGO=$(command -v cargo)
+          cat > "${RUNNER_TEMP}/cargo-auditable-wrapper" <<EOF
+          #!/bin/sh
+          exec "$REAL_CARGO" auditable "\$@"
+          EOF
+          chmod +x "${RUNNER_TEMP}/cargo-auditable-wrapper"
       - uses: PyO3/maturin-action@v1
         env:
-          CARGO: cargo-auditable
+          CARGO: ${{ runner.temp }}/cargo-auditable-wrapper
         with:
           target: ${{ matrix.target }}
           sccache: "true"
@@ -163,12 +183,7 @@ jobs:
         with:
           python-version: "3.13"
           architecture: ${{ matrix.target }}
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-auditable
       - uses: PyO3/maturin-action@v1
-        env:
-          CARGO: cargo-auditable
         with:
           target: ${{ matrix.target }}
           sccache: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   id-token: write
   contents: read
+  attestations: write
+  artifact-metadata: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -71,15 +73,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: PyO3/maturin-action@v1
+        env:
+          CARGO: cargo-auditable
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           sccache: "true"
+          before-script-linux: |
+            cargo install cargo-auditable --locked
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-manylinux-${{ matrix.target }}
           path: dist
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'dist/*.whl'
 
   musllinux:
     name: wheels / musllinux ${{ matrix.target }}
@@ -92,15 +101,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: PyO3/maturin-action@v1
+        env:
+          CARGO: cargo-auditable
         with:
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           sccache: "true"
+          before-script-linux: |
+            cargo install cargo-auditable --locked
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14 --manifest-path rust/Cargo.toml
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-musllinux-${{ matrix.target }}
           path: dist
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'dist/*.whl'
 
   macos:
     name: wheels / macos ${{ matrix.target }}
@@ -115,7 +131,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-auditable
       - uses: PyO3/maturin-action@v1
+        env:
+          CARGO: cargo-auditable
         with:
           target: ${{ matrix.target }}
           sccache: "true"
@@ -124,6 +145,9 @@ jobs:
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'dist/*.whl'
 
   windows:
     name: wheels / windows ${{ matrix.target }}
@@ -139,7 +163,12 @@ jobs:
         with:
           python-version: "3.13"
           architecture: ${{ matrix.target }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-auditable
       - uses: PyO3/maturin-action@v1
+        env:
+          CARGO: cargo-auditable
         with:
           target: ${{ matrix.target }}
           sccache: "true"
@@ -148,6 +177,9 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.target }}
           path: dist
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'dist/*.whl'
 
   sdist:
     name: sdist
@@ -163,6 +195,9 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'dist/*.tar.gz'
 
   release:
     name: Publish to PyPI


### PR DESCRIPTION
## Summary

- Wires `cargo-auditable` into the **Linux and macOS** maturin wheel builds so the compiled `.so` carries its Cargo dep graph — `syft` / `cargo audit bin` can now enumerate the embedded Rust crates instead of seeing `rigour` as a single opaque component. Windows wheels are intentionally skipped (see below).
- Adds `actions/attest-build-provenance@v4` on every wheel-matrix shard (incl. Windows) and on the sdist for GitHub-side verification (`gh attestation verify`, repo Attestations tab).
- Extends workflow permissions: `attestations: write`, `artifact-metadata: write` (`id-token: write` was already present).

The `release` job is untouched — PEP 740 PyPI attestations should auto-engage via the existing tokenless `pypa/gh-action-pypi-publish@release/v1`. To verify on the next tagged release.

Closes #210.

## Why cargo-auditable needs a wrapper

The naive integration is `CARGO=cargo-auditable` on the maturin step. That works for `cargo build`, but maturin invokes `cargo rustc` for cdylib builds (it needs precise control over linker args) — and `cargo-auditable`'s dispatch interprets `cargo-auditable rustc ...` as "rustc-wrapper mode" (treating the literal string `rustc` as the path to the rustc binary), not as a pass-through to `cargo rustc`. The build then fails with `error: Unrecognized option: 'profile'` because rustc doesn't accept cargo's `--profile` flag.

This is [cargo-auditable#211](https://github.com/rust-secure-code/cargo-auditable/issues/211), closed June 2025. Upstream's documented fix in [`REPLACING_CARGO.md`](https://github.com/rust-secure-code/cargo-auditable/blob/master/REPLACING_CARGO.md) is a wrapper script that injects `auditable` as the cargo subcommand:

```sh
#!/bin/sh
exec "$REAL_CARGO" auditable "$@"
```

Set `CARGO=/path/to/wrapper` on the maturin step and maturin's `cargo rustc ...` becomes `cargo auditable rustc ...` which is the supported invocation.

## Implementation notes per platform

- **linux / musllinux** (Docker containers): `before-script-linux` does `RUSTC_WRAPPER= cargo install cargo-auditable --locked` (the `RUSTC_WRAPPER=` prefix is needed because the outer step config sets `RUSTC_WRAPPER=sccache` in the container env, but sccache isn't installed in the container until *after* `before-script-linux` runs), then writes the wrapper to `/usr/local/bin/cargo-auditable-wrapper`. `CARGO` points there.
- **macos**: `taiki-e/install-action@v2` grabs a prebuilt `cargo-auditable`, a follow-up step writes the wrapper to `$RUNNER_TEMP`, `CARGO` points there.
- **windows**: cargo-auditable dropped — upstream's docs have no `.bat`/`.cmd` recipe (`PRs welcome` notice in `REPLACING_CARGO.md`), and rigour's Linux wheels are the ones yente actually consumes downstream. Windows wheels still get the GitHub attestation, just not the embedded dep graph. If a Windows consumer ever needs the BOM, we can revisit with a `.cmd` wrapper.
- **sdist**: attestation only (no compiled bytes to embed into).

## Test plan

- [ ] CI green on this PR (linux + musllinux + macos + windows + sdist)
- [ ] Download a `wheels-manylinux-x86_64` artifact from the PR run, unzip, locate `rigour/_core.*.so`, and run `cargo audit bin <path>` — expect the Rust crate graph listed
- [ ] Same check on a `wheels-macos-*` artifact
- [ ] Confirm Windows wheels DO NOT have the embedded BOM (`cargo audit bin` returns "no auditable data found") — this is the intentional gap
- [ ] Repo **Attestations** tab shows new entries for each wheel-matrix shard + sdist (incl. Windows)
- [ ] `gh attestation verify <wheel> --owner opensanctions` passes locally
- [ ] On next tag: PyPI page shows the PEP 740 attestation badge next to each wheel (if not, pin `pypa/gh-action-pypi-publish` to `v1.11.0+`)
- [ ] Downstream smoke-check from a yente venv: `syft <venv> -o cyclonedx-json` now lists `pyo3`, `aho-corasick`, `icu_*`, etc. as components

🤖 Generated with [Claude Code](https://claude.com/claude-code)