### PR TITLE
Build name-tagger automaton as a noncontiguous NFA

### DIFF
--- a/rust/src/names/matcher.rs
+++ b/rust/src/names/matcher.rs
@@ -35,7 +35,7 @@
 // the valid one. Cost is negligible at our data sizes (~1k needles,
 // ~30-char haystacks, a handful of candidates per call).
 
-use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind, MatchKind};
 use std::collections::HashMap;
 
 /// A multi-needle string search automaton with per-needle payload.
@@ -86,6 +86,15 @@ impl<T> Needles<T> {
             // We implement leftmost-longest ourselves via greedy
             // selection on the overlapping match set.
             .match_kind(MatchKind::Standard)
+            // Force the noncontiguous NFA. The builder default (Auto) does
+            // extra work selecting and constructing a contiguous NFA; for the
+            // large needle sets rigour builds (the name tagger seeds ~470k
+            // aliases) that is ~11% of a one-time build that dominates first-
+            // use latency. `kind` changes the internal representation only,
+            // never which matches are returned; the prefilter stays enabled
+            // and our haystacks are short (~30 chars), so search speed is
+            // unchanged in practice.
+            .kind(Some(AhoCorasickKind::NoncontiguousNFA))
             .build(&keys)
             .expect("needle automaton builds");
         Self { ac, payloads }


### PR DESCRIPTION
## What

`Needles::build` currently lets `AhoCorasickBuilder` pick the automaton kind (the default `AhoCorasickKind::Auto`). This forces `AhoCorasickKind::NoncontiguousNFA`.

## Why

The name tagger seeds the `Needles` automaton with ~470k aliases (mostly from `person_names.txt`). That automaton is built lazily on the first `analyze_names` call with symbols enabled and cached for the process lifetime. On a cold process the build is the dominant startup cost, and the Aho-Corasick construction is ~86% of it.

The default `Auto` kind does extra work selecting and constructing a contiguous NFA. The noncontiguous NFA is cheaper to build. For this workload build cost matters far more than search: the prefilter stays enabled and tagger haystacks are short (~30 chars), so search stays sub-microsecond either way.

`kind` only changes the internal representation, never which matches are returned, so output is unchanged.

## Numbers

Release build, the person tagger's 470,083-needle set:

| builder kind | build time |
| --- | --- |
| Auto (current) | 1624 ms |
| ContiguousNFA | 1516 ms |
| NoncontiguousNFA (this PR) | 1443 ms |

About 180 ms / 11% off the largest single component of first-use latency. Overlapping-search results over a set of probe haystacks are byte-identical across all three kinds.

## Risk

Low. `match_kind` stays `Standard` (required for the overlapping iteration the tagger relies on), the prefilter is untouched, and only the NFA representation changes. The full test suite passes (192 tests).
