### PR TITLE
CI: only attest build provenance on release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           name: wheels-manylinux-${{ matrix.target }}
           path: dist
       - uses: actions/attest-build-provenance@v4
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           subject-path: 'dist/*.whl'
 
@@ -127,6 +128,7 @@ jobs:
           name: wheels-musllinux-${{ matrix.target }}
           path: dist
       - uses: actions/attest-build-provenance@v4
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           subject-path: 'dist/*.whl'
 
@@ -166,6 +168,7 @@ jobs:
           name: wheels-macos-${{ matrix.target }}
           path: dist
       - uses: actions/attest-build-provenance@v4
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           subject-path: 'dist/*.whl'
 
@@ -193,6 +196,7 @@ jobs:
           name: wheels-windows-${{ matrix.target }}
           path: dist
       - uses: actions/attest-build-provenance@v4
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           subject-path: 'dist/*.whl'
 
@@ -211,6 +215,7 @@ jobs:
           name: wheels-sdist
           path: dist
       - uses: actions/attest-build-provenance@v4
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           subject-path: 'dist/*.tar.gz'
 


### PR DESCRIPTION
Gate the five `attest-build-provenance` steps with the same tag-push condition as the PyPI publish job (`github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')`), so attestation runs only when publishing a release.

Previously these steps ran on every PR and branch push and failed (e.g. [this run](https://github.com/opensanctions/rigour/actions/runs/28948949793/job/85890752448)). Wheels still build and upload as artifacts on PRs/branches — only the attestation is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)