### PR TITLE
dates: compare prefix dates as intervals

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -1,0 +1,3 @@
+::: rigour.dates
+
+::: rigour.time

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -1,6 +1,4 @@
 
-::: rigour.time
-
 ::: rigour.units
 
 ::: rigour.boolean

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Identifiers: ids.md
       - Territories: territories.md
       - Addresses: addresses.md
+      - Dates and time: dates.md
       - Languages: langs.md
       - MIME types: mime.md
       - URLs: urls.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires-python = ">= 3.10"
 dependencies = [
     "pyyaml >= 5.0.0, < 7.0.0",
     "normality >= 3.0.1, < 4.0.0",
+    "prefixdate >= 0.5.0, < 1.0.0",
     "orjson >= 3.0.0, < 4.0.0",
     "python-stdnum >= 2.0, < 3.0.0",
     "jinja2 >= 3.1.0, < 4.0.0",

--- a/rigour/dates.py
+++ b/rigour/dates.py
@@ -4,6 +4,13 @@ A prefix date such as ``2026`` or ``2026-06`` represents an interval, rather
 than the first instant of that year or month. Use the string wrappers for
 one-off comparisons, or parse a [DateInterval][rigour.dates.DateInterval] once
 when comparing the same value repeatedly.
+
+Age and recency checks use the same comparisons with a shifted reference:
+
+```python
+cutoff = now - max_age
+is_recent = not ended_before(value, cutoff)
+```
 """
 
 import re
@@ -45,7 +52,7 @@ def _ensure_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
-def require_utc(value: str) -> datetime:
+def parse_utc(value: str) -> datetime:
     """Parse an exact timestamp as an aware UTC datetime.
 
     Use this at a prefix-date boundary where an exact timestamp may carry an
@@ -74,8 +81,9 @@ def prefix_interval(value: str) -> DateInterval:
     """Expand a canonical prefix date into its represented UTC interval.
 
     Use this at the boundary between prefix-date strings and interval comparison.
-    Exact timestamps with offsets are converted to UTC before their one-second
-    interval is constructed.
+    Feed it normalized property values only, not uncleaned source strings. Exact
+    timestamps with offsets are converted to UTC before their one-second interval
+    is constructed.
 
     Args:
         value: Canonical prefix date, from year through second precision.
@@ -88,7 +96,7 @@ def prefix_interval(value: str) -> DateInterval:
             carries a timezone.
     """
     if _SECOND_TIMESTAMP_RE.fullmatch(value) is not None:
-        start = require_utc(value)
+        start = parse_utc(value)
         return DateInterval(start=start, end=start + timedelta(seconds=1))
     has_timezone = value.endswith("Z") or (
         "T" in value and _TIMEZONE_SUFFIX_RE.search(value) is not None

--- a/rigour/dates.py
+++ b/rigour/dates.py
@@ -1,88 +1,109 @@
 """Compare imprecise FtM dates without pretending they are exact instants.
 
-An FtM date is a prefix such as ``2026`` or ``2026-06``. Each prefix describes
-an interval, not the first instant in that interval: ``2026`` could mean any
-time during that year. The public helpers below deliberately answer questions
-about the interval's start or end so callers do not accidentally fall back to
-lexicographic string comparisons.
+An FtM prefix date such as ``2026`` or ``2026-06`` represents an interval,
+rather than the first instant of that year or month. Use the string wrappers
+for one-off comparisons, or parse a [DateInterval][rigour.dates.DateInterval]
+once when comparing the same value repeatedly.
 """
 
 import re
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 
 from prefixdate import Precision, parse
 
 from rigour.util import MEMO_SMALL
 
-# ``prefixdate`` intentionally accepts messy source data and may parse only the
-# valid prefix of a string. These helpers operate on normalized FtM values, so
-# first require the whole input to have a canonical prefix-date shape. Calendar
-# validation and precision detection are still delegated to ``prefixdate``.
-_PREFIX_RE = re.compile(
-    r"^[12]\d{3}"
-    r"(?:-\d{2}"
-    r"(?:-\d{2}"
-    r"(?:T\d{2}"
-    r"(?::\d{2}"
-    r"(?::\d{2})?"
-    r")?"
-    r")?"
-    r")?"
-    r")?$"
+_TIMEZONE_SUFFIX_RE = re.compile(r"(?:Z|[+-]\d{2}(?::?\d{2})?)$")
+_SECOND_TIMESTAMP_RE = re.compile(
+    r"^[12]\d{3}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+    r"(?:Z|[+-]\d{2}(?::?\d{2})?)?$"
 )
-# A reference is a point in time rather than another imprecise interval. Require
-# seconds so comparisons against a day or month cannot acquire hidden semantics.
-_REFERENCE_RE = re.compile(r"^[12]\d{3}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$")
-_OFFSET_RE = re.compile(r"(?P<sign>[+-])(?P<hour>\d{2})(?::?(?P<minute>\d{2}))?$")
 
 
-def _require_string(value: object, name: str) -> str:
-    if not isinstance(value, str):
-        raise TypeError(f"{name} must be a string")
-    return value
+@dataclass(frozen=True)
+class DateInterval:
+    """Represent every possible instant described by an imprecise date.
+
+    Use this parsed form when applying multiple comparisons to the same FtM
+    date. Both bounds are timezone-aware UTC datetimes and ``end`` is exclusive.
+
+    Attributes:
+        start: Earliest instant represented by the date.
+        end: First instant after the represented interval.
+    """
+
+    start: datetime
+    end: datetime
 
 
-def _without_timezone(value: str) -> tuple[str, bool]:
-    """Remove an explicit UTC suffix while rejecting offsets needing conversion."""
-    if value.endswith("Z"):
-        return value[:-1], True
-    if "T" not in value:
-        return value, False
-    match = _OFFSET_RE.search(value)
-    if match is None:
-        return value, False
-    hour = int(match.group("hour"))
-    minute = int(match.group("minute") or 0)
-    # FtM timestamps are either naive UTC or explicitly UTC. Converting another
-    # offset here could hide an upstream violation of that data contract.
-    if hour != 0 or minute != 0:
-        raise ValueError("date timestamps must be naive or UTC")
-    return value[: match.start()], True
+def _ensure_utc(value: datetime) -> datetime:
+    """Adapt legacy naive-UTC values to aware UTC datetimes."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def require_utc(value: str) -> datetime:
+    """Parse an exact timestamp as an aware UTC datetime.
+
+    Use this at an FtM date boundary where an exact timestamp may carry an
+    offset. Naive timestamps use the ecosystem convention of implicit UTC.
+
+    Args:
+        value: Canonical second-precision timestamp.
+
+    Returns:
+        The represented instant as a timezone-aware UTC datetime.
+
+    Raises:
+        ValueError: The timestamp is invalid or is not precise to the second.
+    """
+    if _SECOND_TIMESTAMP_RE.fullmatch(value) is None:
+        raise ValueError(f"Invalid exact timestamp: {value!r}")
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid timestamp: {value!r}") from exc
+    return _ensure_utc(timestamp)
 
 
 @lru_cache(maxsize=MEMO_SMALL)
-def _date_bounds(value: str) -> tuple[datetime, datetime]:
-    """Expand a prefix date into a half-open ``[start, end)`` interval."""
-    text, had_timezone = _without_timezone(value)
-    if _PREFIX_RE.fullmatch(text) is None:
-        raise ValueError(f"Invalid prefix date: {value!r}")
+def prefix_interval(value: str) -> DateInterval:
+    """Expand a canonical prefix date into its represented UTC interval.
 
-    # The shape check above prevents partial parses. ``prefixdate`` remains the
-    # source of truth for real dates (including leap years) and their precision.
-    prefix = parse(text)
-    if prefix.dt is None or prefix.text is None or prefix.precision == Precision.EMPTY:
-        raise ValueError(f"Invalid prefix date: {value!r}")
-    if prefix.text != text:
-        raise ValueError(f"Prefix date is not canonical: {value!r}")
-    if had_timezone and prefix.precision != Precision.SECOND:
+    Use this at the boundary between FtM string values and interval comparison.
+    Exact timestamps with offsets are converted to UTC before their one-second
+    interval is constructed.
+
+    Args:
+        value: Canonical FtM prefix date, from year through second precision.
+
+    Returns:
+        The timezone-aware UTC, half-open interval represented by the value.
+
+    Raises:
+        ValueError: The value is invalid or non-canonical, or an imprecise value
+            carries a timezone.
+    """
+    if _SECOND_TIMESTAMP_RE.fullmatch(value) is not None:
+        start = require_utc(value)
+        return DateInterval(start=start, end=start + timedelta(seconds=1))
+    has_timezone = value.endswith("Z") or (
+        "T" in value and _TIMEZONE_SUFFIX_RE.search(value) is not None
+    )
+    if has_timezone:
         raise ValueError("timezone suffixes require second precision")
 
-    start = prefix.dt.replace(tzinfo=None)
+    prefix = parse(value)
+    if prefix.dt is None or prefix.text is None or prefix.precision == Precision.EMPTY:
+        raise ValueError(f"Invalid prefix date: {value!r}")
+    if prefix.text != value:
+        raise ValueError(f"Prefix date is not canonical: {value!r}")
+
+    start = prefix.dt.replace(tzinfo=timezone.utc)
     precision = prefix.precision
-    # Advancing by one unit gives an exclusive end without inventing an
-    # artificial "latest" microsecond. It also makes boundaries exact: a day
-    # used as an end date expires at midnight at the start of the next day.
     if precision == Precision.YEAR:
         end = start.replace(year=start.year + 1)
     elif precision == Precision.MONTH:
@@ -100,66 +121,75 @@ def _date_bounds(value: str) -> tuple[datetime, datetime]:
         end = start + timedelta(seconds=1)
     else:
         raise ValueError(f"Unsupported prefix date precision: {value!r}")
-    return start, end
+    return DateInterval(start=start, end=end)
 
 
-@lru_cache(maxsize=MEMO_SMALL)
-def _reference_datetime(value: str) -> datetime:
-    """Parse the exact point against which a prefix interval is compared."""
-    text, _ = _without_timezone(value)
-    if _REFERENCE_RE.fullmatch(text) is None:
-        raise ValueError(f"Invalid reference timestamp: {value!r}")
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError as exc:
-        raise ValueError(f"Invalid reference timestamp: {value!r}") from exc
+def interval_ended_before(value: DateInterval, reference: datetime) -> bool:
+    """Check whether an interval has completely elapsed before a point in time.
+
+    Use this for end dates and age cutoffs when the prefix date has already been
+    parsed.
+
+    Args:
+        value: Interval to compare.
+        reference: Timezone-aware UTC point in time.
+
+    Returns:
+        ``True`` if every instant represented by the interval precedes the
+        reference.
+    """
+    return value.end <= reference
 
 
-def ended_before(value: str, reference: str) -> bool:
-    """Check whether a prefix date has completely elapsed before a timestamp.
+def interval_starts_after(value: DateInterval, reference: datetime) -> bool:
+    """Check whether an interval begins strictly after a point in time.
 
-    Use this for end dates and age cutoffs where an imprecise date should remain
-    current until its latest possible instant has passed.
+    Use this for start dates and future-date guardrails when the prefix date has
+    already been parsed.
+
+    Args:
+        value: Interval to compare.
+        reference: Timezone-aware UTC point in time.
+
+    Returns:
+        ``True`` if the earliest instant in the interval follows the reference.
+    """
+    return value.start > reference
+
+
+def ended_before(value: str, reference: datetime) -> bool:
+    """Check whether an FtM prefix date has completely elapsed.
+
+    Use this string wrapper for one-off end-date and age-cutoff checks. Parse
+    once with [prefix_interval][rigour.dates.prefix_interval] when making
+    several comparisons against the same value.
 
     Args:
         value: Canonical FtM prefix date, from year through second precision.
-        reference: Exact naive or UTC ISO timestamp, including seconds.
+        reference: UTC point in time. Legacy naive values are interpreted as
+            UTC; aware values are converted to UTC.
 
     Returns:
-        True if every instant represented by ``value`` precedes ``reference``.
-
-    Raises:
-        TypeError: If either argument is not a string.
-        ValueError: If either argument is invalid or uses a non-UTC offset.
+        ``True`` if every instant represented by the date precedes the
+        reference.
     """
-    value = _require_string(value, "value")
-    reference = _require_string(reference, "reference")
-    _, end = _date_bounds(value)
-    # With an exclusive end, equality means the whole represented interval has
-    # elapsed: 2026 ends exactly at 2027-01-01T00:00:00.
-    return end <= _reference_datetime(reference)
+    return interval_ended_before(prefix_interval(value), _ensure_utc(reference))
 
 
-def starts_after(value: str, reference: str) -> bool:
-    """Check whether a prefix date begins after a timestamp.
+def starts_after(value: str, reference: datetime) -> bool:
+    """Check whether an FtM prefix date begins after a point in time.
 
-    Use this for start dates and future-date guardrails where even the earliest
-    possible instant must be later than the reference.
+    Use this string wrapper for one-off start-date and future-date checks. Parse
+    once with [prefix_interval][rigour.dates.prefix_interval] when reusing the
+    same value.
 
     Args:
         value: Canonical FtM prefix date, from year through second precision.
-        reference: Exact naive or UTC ISO timestamp, including seconds.
+        reference: UTC point in time. Legacy naive values are interpreted as
+            UTC; aware values are converted to UTC.
 
     Returns:
-        True if every instant represented by ``value`` follows ``reference``.
-
-    Raises:
-        TypeError: If either argument is not a string.
-        ValueError: If either argument is invalid or uses a non-UTC offset.
+        ``True`` if the earliest instant represented by the date follows the
+        reference.
     """
-    value = _require_string(value, "value")
-    reference = _require_string(reference, "reference")
-    start, _ = _date_bounds(value)
-    # Strict comparison keeps a date beginning exactly at the reference from
-    # being labelled as starting after it.
-    return start > _reference_datetime(reference)
+    return interval_starts_after(prefix_interval(value), _ensure_utc(reference))

--- a/rigour/dates.py
+++ b/rigour/dates.py
@@ -1,0 +1,165 @@
+"""Compare imprecise FtM dates without pretending they are exact instants.
+
+An FtM date is a prefix such as ``2026`` or ``2026-06``. Each prefix describes
+an interval, not the first instant in that interval: ``2026`` could mean any
+time during that year. The public helpers below deliberately answer questions
+about the interval's start or end so callers do not accidentally fall back to
+lexicographic string comparisons.
+"""
+
+import re
+from datetime import datetime, timedelta
+from functools import lru_cache
+
+from prefixdate import Precision, parse
+
+from rigour.util import MEMO_SMALL
+
+# ``prefixdate`` intentionally accepts messy source data and may parse only the
+# valid prefix of a string. These helpers operate on normalized FtM values, so
+# first require the whole input to have a canonical prefix-date shape. Calendar
+# validation and precision detection are still delegated to ``prefixdate``.
+_PREFIX_RE = re.compile(
+    r"^[12]\d{3}"
+    r"(?:-\d{2}"
+    r"(?:-\d{2}"
+    r"(?:T\d{2}"
+    r"(?::\d{2}"
+    r"(?::\d{2})?"
+    r")?"
+    r")?"
+    r")?"
+    r")?$"
+)
+# A reference is a point in time rather than another imprecise interval. Require
+# seconds so comparisons against a day or month cannot acquire hidden semantics.
+_REFERENCE_RE = re.compile(r"^[12]\d{3}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$")
+_OFFSET_RE = re.compile(r"(?P<sign>[+-])(?P<hour>\d{2})(?::?(?P<minute>\d{2}))?$")
+
+
+def _require_string(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    return value
+
+
+def _without_timezone(value: str) -> tuple[str, bool]:
+    """Remove an explicit UTC suffix while rejecting offsets needing conversion."""
+    if value.endswith("Z"):
+        return value[:-1], True
+    if "T" not in value:
+        return value, False
+    match = _OFFSET_RE.search(value)
+    if match is None:
+        return value, False
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or 0)
+    # FtM timestamps are either naive UTC or explicitly UTC. Converting another
+    # offset here could hide an upstream violation of that data contract.
+    if hour != 0 or minute != 0:
+        raise ValueError("date timestamps must be naive or UTC")
+    return value[: match.start()], True
+
+
+@lru_cache(maxsize=MEMO_SMALL)
+def _date_bounds(value: str) -> tuple[datetime, datetime]:
+    """Expand a prefix date into a half-open ``[start, end)`` interval."""
+    text, had_timezone = _without_timezone(value)
+    if _PREFIX_RE.fullmatch(text) is None:
+        raise ValueError(f"Invalid prefix date: {value!r}")
+
+    # The shape check above prevents partial parses. ``prefixdate`` remains the
+    # source of truth for real dates (including leap years) and their precision.
+    prefix = parse(text)
+    if prefix.dt is None or prefix.text is None or prefix.precision == Precision.EMPTY:
+        raise ValueError(f"Invalid prefix date: {value!r}")
+    if prefix.text != text:
+        raise ValueError(f"Prefix date is not canonical: {value!r}")
+    if had_timezone and prefix.precision != Precision.SECOND:
+        raise ValueError("timezone suffixes require second precision")
+
+    start = prefix.dt.replace(tzinfo=None)
+    precision = prefix.precision
+    # Advancing by one unit gives an exclusive end without inventing an
+    # artificial "latest" microsecond. It also makes boundaries exact: a day
+    # used as an end date expires at midnight at the start of the next day.
+    if precision == Precision.YEAR:
+        end = start.replace(year=start.year + 1)
+    elif precision == Precision.MONTH:
+        if start.month == 12:
+            end = start.replace(year=start.year + 1, month=1)
+        else:
+            end = start.replace(month=start.month + 1)
+    elif precision == Precision.DAY:
+        end = start + timedelta(days=1)
+    elif precision == Precision.HOUR:
+        end = start + timedelta(hours=1)
+    elif precision == Precision.MINUTE:
+        end = start + timedelta(minutes=1)
+    elif precision == Precision.SECOND:
+        end = start + timedelta(seconds=1)
+    else:
+        raise ValueError(f"Unsupported prefix date precision: {value!r}")
+    return start, end
+
+
+@lru_cache(maxsize=MEMO_SMALL)
+def _reference_datetime(value: str) -> datetime:
+    """Parse the exact point against which a prefix interval is compared."""
+    text, _ = _without_timezone(value)
+    if _REFERENCE_RE.fullmatch(text) is None:
+        raise ValueError(f"Invalid reference timestamp: {value!r}")
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"Invalid reference timestamp: {value!r}") from exc
+
+
+def ended_before(value: str, reference: str) -> bool:
+    """Check whether a prefix date has completely elapsed before a timestamp.
+
+    Use this for end dates and age cutoffs where an imprecise date should remain
+    current until its latest possible instant has passed.
+
+    Args:
+        value: Canonical FtM prefix date, from year through second precision.
+        reference: Exact naive or UTC ISO timestamp, including seconds.
+
+    Returns:
+        True if every instant represented by ``value`` precedes ``reference``.
+
+    Raises:
+        TypeError: If either argument is not a string.
+        ValueError: If either argument is invalid or uses a non-UTC offset.
+    """
+    value = _require_string(value, "value")
+    reference = _require_string(reference, "reference")
+    _, end = _date_bounds(value)
+    # With an exclusive end, equality means the whole represented interval has
+    # elapsed: 2026 ends exactly at 2027-01-01T00:00:00.
+    return end <= _reference_datetime(reference)
+
+
+def starts_after(value: str, reference: str) -> bool:
+    """Check whether a prefix date begins after a timestamp.
+
+    Use this for start dates and future-date guardrails where even the earliest
+    possible instant must be later than the reference.
+
+    Args:
+        value: Canonical FtM prefix date, from year through second precision.
+        reference: Exact naive or UTC ISO timestamp, including seconds.
+
+    Returns:
+        True if every instant represented by ``value`` follows ``reference``.
+
+    Raises:
+        TypeError: If either argument is not a string.
+        ValueError: If either argument is invalid or uses a non-UTC offset.
+    """
+    value = _require_string(value, "value")
+    reference = _require_string(reference, "reference")
+    start, _ = _date_bounds(value)
+    # Strict comparison keeps a date beginning exactly at the reference from
+    # being labelled as starting after it.
+    return start > _reference_datetime(reference)

--- a/rigour/dates.py
+++ b/rigour/dates.py
@@ -1,9 +1,9 @@
-"""Compare imprecise FtM dates without pretending they are exact instants.
+"""Compare prefix dates without pretending they are exact instants.
 
-An FtM prefix date such as ``2026`` or ``2026-06`` represents an interval,
-rather than the first instant of that year or month. Use the string wrappers
-for one-off comparisons, or parse a [DateInterval][rigour.dates.DateInterval]
-once when comparing the same value repeatedly.
+A prefix date such as ``2026`` or ``2026-06`` represents an interval, rather
+than the first instant of that year or month. Use the string wrappers for
+one-off comparisons, or parse a [DateInterval][rigour.dates.DateInterval] once
+when comparing the same value repeatedly.
 """
 
 import re
@@ -26,7 +26,7 @@ _SECOND_TIMESTAMP_RE = re.compile(
 class DateInterval:
     """Represent every possible instant described by an imprecise date.
 
-    Use this parsed form when applying multiple comparisons to the same FtM
+    Use this parsed form when applying multiple comparisons to the same prefix
     date. Both bounds are timezone-aware UTC datetimes and ``end`` is exclusive.
 
     Attributes:
@@ -48,7 +48,7 @@ def _ensure_utc(value: datetime) -> datetime:
 def require_utc(value: str) -> datetime:
     """Parse an exact timestamp as an aware UTC datetime.
 
-    Use this at an FtM date boundary where an exact timestamp may carry an
+    Use this at a prefix-date boundary where an exact timestamp may carry an
     offset. Naive timestamps use the ecosystem convention of implicit UTC.
 
     Args:
@@ -73,12 +73,12 @@ def require_utc(value: str) -> datetime:
 def prefix_interval(value: str) -> DateInterval:
     """Expand a canonical prefix date into its represented UTC interval.
 
-    Use this at the boundary between FtM string values and interval comparison.
+    Use this at the boundary between prefix-date strings and interval comparison.
     Exact timestamps with offsets are converted to UTC before their one-second
     interval is constructed.
 
     Args:
-        value: Canonical FtM prefix date, from year through second precision.
+        value: Canonical prefix date, from year through second precision.
 
     Returns:
         The timezone-aware UTC, half-open interval represented by the value.
@@ -158,14 +158,14 @@ def interval_starts_after(value: DateInterval, reference: datetime) -> bool:
 
 
 def ended_before(value: str, reference: datetime) -> bool:
-    """Check whether an FtM prefix date has completely elapsed.
+    """Check whether a prefix date has completely elapsed.
 
     Use this string wrapper for one-off end-date and age-cutoff checks. Parse
     once with [prefix_interval][rigour.dates.prefix_interval] when making
     several comparisons against the same value.
 
     Args:
-        value: Canonical FtM prefix date, from year through second precision.
+        value: Canonical prefix date, from year through second precision.
         reference: UTC point in time. Legacy naive values are interpreted as
             UTC; aware values are converted to UTC.
 
@@ -177,14 +177,14 @@ def ended_before(value: str, reference: datetime) -> bool:
 
 
 def starts_after(value: str, reference: datetime) -> bool:
-    """Check whether an FtM prefix date begins after a point in time.
+    """Check whether a prefix date begins after a point in time.
 
     Use this string wrapper for one-off start-date and future-date checks. Parse
     once with [prefix_interval][rigour.dates.prefix_interval] when reusing the
     same value.
 
     Args:
-        value: Canonical FtM prefix date, from year through second precision.
+        value: Canonical prefix date, from year through second precision.
         reference: UTC point in time. Legacy naive values are interpreted as
             UTC; aware values are converted to UTC.
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,56 +1,123 @@
-from typing import Any
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from rigour.dates import ended_before, starts_after
+from rigour.dates import (
+    DateInterval,
+    ended_before,
+    interval_ended_before,
+    interval_starts_after,
+    prefix_interval,
+    require_utc,
+    starts_after,
+)
+
+
+def dt(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def test_ended_before_prefix_precision() -> None:
-    assert not ended_before("2026", "2026-07-17T12:00:00")
-    assert ended_before("2026", "2027-01-01T00:00:00")
+    assert not ended_before("2026", dt("2026-07-17T12:00:00"))
+    assert ended_before("2026", dt("2027-01-01T00:00:00"))
 
-    assert not ended_before("2026-06", "2026-06-30T23:59:59")
-    assert ended_before("2026-06", "2026-07-01T00:00:00")
+    assert not ended_before("2026-06", dt("2026-06-30T23:59:59"))
+    assert ended_before("2026-06", dt("2026-07-01T00:00:00"))
 
-    assert not ended_before("2026-06-15", "2026-06-15T23:59:59")
-    assert ended_before("2026-06-15", "2026-06-16T00:00:00")
+    assert not ended_before("2026-06-15", dt("2026-06-15T23:59:59"))
+    assert ended_before("2026-06-15", dt("2026-06-16T00:00:00"))
 
-    assert not ended_before("2026-06-15T12", "2026-06-15T12:59:59")
-    assert ended_before("2026-06-15T12", "2026-06-15T13:00:00")
+    assert not ended_before("2026-06-15T12", dt("2026-06-15T12:59:59"))
+    assert ended_before("2026-06-15T12", dt("2026-06-15T13:00:00"))
 
-    assert not ended_before("2026-06-15T12:30", "2026-06-15T12:30:59")
-    assert ended_before("2026-06-15T12:30", "2026-06-15T12:31:00")
+    assert not ended_before("2026-06-15T12:30", dt("2026-06-15T12:30:59"))
+    assert ended_before("2026-06-15T12:30", dt("2026-06-15T12:31:00"))
 
-    assert not ended_before("2026-06-15T12:30:45", "2026-06-15T12:30:45.5")
-    assert ended_before("2026-06-15T12:30:45", "2026-06-15T12:30:46")
+    assert not ended_before(
+        "2026-06-15T12:30:45", dt("2026-06-15T12:30:45.500000")
+    )
+    assert ended_before("2026-06-15T12:30:45", dt("2026-06-15T12:30:46"))
 
 
 def test_starts_after_boundaries() -> None:
-    assert starts_after("2027", "2026-12-31T23:59:59")
-    assert not starts_after("2027", "2027-01-01T00:00:00")
-    assert starts_after("2068-07-16", "2026-07-17T12:00:00")
-    assert not starts_after("2026", "2026-07-17T12:00:00")
+    assert starts_after("2027", dt("2026-12-31T23:59:59"))
+    assert not starts_after("2027", dt("2027-01-01T00:00:00"))
+    assert starts_after("2068-07-16", dt("2026-07-17T12:00:00"))
+    assert not starts_after("2026", dt("2026-07-17T12:00:00"))
 
 
 def test_calendar_boundaries() -> None:
-    assert ended_before("2024-02", "2024-03-01T00:00:00")
-    assert ended_before("2024-02-29", "2024-03-01T00:00:00")
-    assert ended_before("2026-12", "2027-01-01T00:00:00")
+    assert ended_before("2024-02", dt("2024-03-01T00:00:00"))
+    assert ended_before("2024-02-29", dt("2024-03-01T00:00:00"))
+    assert ended_before("2026-12", dt("2027-01-01T00:00:00"))
+
+
+def test_prefix_interval_uses_aware_utc_bounds() -> None:
+    interval = prefix_interval("2026-06")
+    assert interval == DateInterval(
+        start=dt("2026-06-01T00:00:00+00:00"),
+        end=dt("2026-07-01T00:00:00+00:00"),
+    )
+
+
+def test_interval_and_string_predicates_are_equivalent() -> None:
+    interval = prefix_interval("2026")
+    reference = dt("2027-01-01T00:00:00")
+    assert interval_ended_before(interval, reference) == ended_before("2026", reference)
+    assert interval_starts_after(interval, reference) == starts_after("2026", reference)
+
+
+def test_string_wrapper_accepts_legacy_naive_utc_reference() -> None:
+    interval = prefix_interval("2026")
+    reference = datetime(2027, 1, 1)
+    assert ended_before("2026", reference)
+    with pytest.raises(TypeError, match="offset-naive and offset-aware"):
+        interval_ended_before(interval, reference)
+
+
+def test_string_wrapper_converts_aware_reference_to_utc() -> None:
+    assert ended_before("2026", dt("2027-01-01T01:00:00+01:00"))
 
 
 @pytest.mark.parametrize("suffix", ["Z", "+00", "+0000", "+00:00"])
 def test_utc_suffixes(suffix: str) -> None:
-    reference = f"2027-01-01T00:00:00{suffix}"
-    assert ended_before("2026", reference)
-    assert ended_before(f"2026-12-31T23:59:59{suffix}", reference)
+    value = f"2026-12-31T23:59:59{suffix}"
+    assert require_utc(value) == dt("2026-12-31T23:59:59")
+    assert ended_before(value, dt("2027-01-01T00:00:00Z"))
 
 
-@pytest.mark.parametrize("suffix", ["+01", "+0130", "+01:30", "-04:00"])
-def test_non_utc_offsets_rejected(suffix: str) -> None:
-    with pytest.raises(ValueError, match="naive or UTC"):
-        ended_before("2026", f"2027-01-01T00:00:00{suffix}")
-    with pytest.raises(ValueError, match="naive or UTC"):
-        ended_before(f"2026-12-31T23:59:59{suffix}", "2027-01-01T00:00:00")
+@pytest.mark.parametrize(
+    ("value", "normalized"),
+    [
+        ("2026-12-31T23:30:00-01:00", "2027-01-01T00:30:00"),
+        ("2027-01-01T00:30:00+01:00", "2026-12-31T23:30:00"),
+        ("2026-07-17T12:30:00+0130", "2026-07-17T11:00:00"),
+        ("2026-07-17T12:30:00-04", "2026-07-17T16:30:00"),
+    ],
+)
+def test_non_utc_offsets_are_converted(value: str, normalized: str) -> None:
+    assert require_utc(value) == dt(normalized)
+    interval = prefix_interval(value)
+    assert interval.start == dt(normalized)
+    assert interval.end == interval.start + timedelta(seconds=1)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026Z",
+        "2026-07Z",
+        "2026-07-17Z",
+        "2026-07-17T12+01:00",
+        "2026-07-17T12:30-04:00",
+    ],
+)
+def test_timezone_requires_second_precision(value: str) -> None:
+    with pytest.raises(ValueError, match="second precision"):
+        prefix_interval(value)
 
 
 @pytest.mark.parametrize(
@@ -63,38 +130,8 @@ def test_non_utc_offsets_rejected(suffix: str) -> None:
         " 2026-07-17",
         "2026-07-17 ",
         "2026-07-17T12:30:45.123456",
-        "2026-07-17Z",
     ],
 )
 def test_invalid_prefix_dates(value: str) -> None:
     with pytest.raises(ValueError):
-        ended_before(value, "2027-01-01T00:00:00")
-
-
-@pytest.mark.parametrize(
-    "reference",
-    [
-        "",
-        "2027",
-        "2027-01-01",
-        "2027-01-01T00:00",
-        "2027-02-29T00:00:00",
-        "2027-01-01T00:00:00junk",
-        " 2027-01-01T00:00:00",
-    ],
-)
-def test_invalid_references(reference: str) -> None:
-    with pytest.raises(ValueError):
-        ended_before("2026", reference)
-
-
-@pytest.mark.parametrize("value", [None, 2026, [], object()])
-def test_non_string_value_rejected(value: Any) -> None:
-    with pytest.raises(TypeError, match="value must be a string"):
-        ended_before(value, "2027-01-01T00:00:00")  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize("reference", [None, 2026, [], object()])
-def test_non_string_reference_rejected(reference: Any) -> None:
-    with pytest.raises(TypeError, match="reference must be a string"):
-        starts_after("2026", reference)  # type: ignore[arg-type]
+        prefix_interval(value)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -7,8 +7,8 @@ from rigour.dates import (
     ended_before,
     interval_ended_before,
     interval_starts_after,
+    parse_utc,
     prefix_interval,
-    require_utc,
     starts_after,
 )
 
@@ -85,7 +85,7 @@ def test_string_wrapper_converts_aware_reference_to_utc() -> None:
 @pytest.mark.parametrize("suffix", ["Z", "+00", "+0000", "+00:00"])
 def test_utc_suffixes(suffix: str) -> None:
     value = f"2026-12-31T23:59:59{suffix}"
-    assert require_utc(value) == dt("2026-12-31T23:59:59")
+    assert parse_utc(value) == dt("2026-12-31T23:59:59")
     assert ended_before(value, dt("2027-01-01T00:00:00Z"))
 
 
@@ -99,7 +99,7 @@ def test_utc_suffixes(suffix: str) -> None:
     ],
 )
 def test_non_utc_offsets_are_converted(value: str, normalized: str) -> None:
-    assert require_utc(value) == dt(normalized)
+    assert parse_utc(value) == dt(normalized)
     interval = prefix_interval(value)
     assert interval.start == dt(normalized)
     assert interval.end == interval.start + timedelta(seconds=1)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+import pytest
+
+from rigour.dates import ended_before, starts_after
+
+
+def test_ended_before_prefix_precision() -> None:
+    assert not ended_before("2026", "2026-07-17T12:00:00")
+    assert ended_before("2026", "2027-01-01T00:00:00")
+
+    assert not ended_before("2026-06", "2026-06-30T23:59:59")
+    assert ended_before("2026-06", "2026-07-01T00:00:00")
+
+    assert not ended_before("2026-06-15", "2026-06-15T23:59:59")
+    assert ended_before("2026-06-15", "2026-06-16T00:00:00")
+
+    assert not ended_before("2026-06-15T12", "2026-06-15T12:59:59")
+    assert ended_before("2026-06-15T12", "2026-06-15T13:00:00")
+
+    assert not ended_before("2026-06-15T12:30", "2026-06-15T12:30:59")
+    assert ended_before("2026-06-15T12:30", "2026-06-15T12:31:00")
+
+    assert not ended_before("2026-06-15T12:30:45", "2026-06-15T12:30:45.5")
+    assert ended_before("2026-06-15T12:30:45", "2026-06-15T12:30:46")
+
+
+def test_starts_after_boundaries() -> None:
+    assert starts_after("2027", "2026-12-31T23:59:59")
+    assert not starts_after("2027", "2027-01-01T00:00:00")
+    assert starts_after("2068-07-16", "2026-07-17T12:00:00")
+    assert not starts_after("2026", "2026-07-17T12:00:00")
+
+
+def test_calendar_boundaries() -> None:
+    assert ended_before("2024-02", "2024-03-01T00:00:00")
+    assert ended_before("2024-02-29", "2024-03-01T00:00:00")
+    assert ended_before("2026-12", "2027-01-01T00:00:00")
+
+
+@pytest.mark.parametrize("suffix", ["Z", "+00", "+0000", "+00:00"])
+def test_utc_suffixes(suffix: str) -> None:
+    reference = f"2027-01-01T00:00:00{suffix}"
+    assert ended_before("2026", reference)
+    assert ended_before(f"2026-12-31T23:59:59{suffix}", reference)
+
+
+@pytest.mark.parametrize("suffix", ["+01", "+0130", "+01:30", "-04:00"])
+def test_non_utc_offsets_rejected(suffix: str) -> None:
+    with pytest.raises(ValueError, match="naive or UTC"):
+        ended_before("2026", f"2027-01-01T00:00:00{suffix}")
+    with pytest.raises(ValueError, match="naive or UTC"):
+        ended_before(f"2026-12-31T23:59:59{suffix}", "2027-01-01T00:00:00")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "2026-7",
+        "2026-02-29",
+        "2026-07-17junk",
+        " 2026-07-17",
+        "2026-07-17 ",
+        "2026-07-17T12:30:45.123456",
+        "2026-07-17Z",
+    ],
+)
+def test_invalid_prefix_dates(value: str) -> None:
+    with pytest.raises(ValueError):
+        ended_before(value, "2027-01-01T00:00:00")
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "",
+        "2027",
+        "2027-01-01",
+        "2027-01-01T00:00",
+        "2027-02-29T00:00:00",
+        "2027-01-01T00:00:00junk",
+        " 2027-01-01T00:00:00",
+    ],
+)
+def test_invalid_references(reference: str) -> None:
+    with pytest.raises(ValueError):
+        ended_before("2026", reference)
+
+
+@pytest.mark.parametrize("value", [None, 2026, [], object()])
+def test_non_string_value_rejected(value: Any) -> None:
+    with pytest.raises(TypeError, match="value must be a string"):
+        ended_before(value, "2027-01-01T00:00:00")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("reference", [None, 2026, [], object()])
+def test_non_string_reference_rejected(reference: Any) -> None:
+    with pytest.raises(TypeError, match="reference must be a string"):
+        starts_after("2026", reference)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- represent canonical prefix dates as half-open UTC `DateInterval` values
- expose `ended_before` and `starts_after` wrappers for conservative date comparisons
- normalize naive and offset-bearing exact timestamps to aware UTC datetimes
- document prefix-date and time helpers together in the MkDocs navigation

This deliberately uses `prefixdate` for calendar validation and precision detection instead of reimplementing those rules in Rigour. The version constraint matches FollowTheMoney, avoiding a dependency-resolution conflict.

Callers must pass normalized property values to `prefix_interval`; raw source strings should be cleaned before comparison.

Closes #250

## Test plan

- `pytest -q` (510 passed)
- `mypy --strict rigour`
- `mkdocs build --strict -f mkdocs.yml`
- `git diff --check`