### PR TITLE
Resolve BCP 47-style language tags via their primary subtag

### DIFF
--- a/rigour/langs/__init__.py
+++ b/rigour/langs/__init__.py
@@ -67,18 +67,26 @@ __all__ = [
 def iso_639_alpha3(code: str) -> Optional[str]:
     """Convert a given language identifier into an ISO 639 Part 2 code, such
     as "eng" or "deu". This will accept language codes in the two- or three-
-    letter format, and some language names. If the given string cannot be
-    converted, ``None`` will be returned.
+    letter format, some language names, and IETF/BCP 47-style tags with a
+    script or region subtag (e.g. "zh-Hans", "pt-BR"), which resolve to the
+    code of their primary subtag. If the given string cannot be converted,
+    ``None`` will be returned.
 
     >>> iso_639_alpha3('en')
     'eng'
     """
     norm = normalize_code(code)
-    if norm is not None:
-        norm = ISO3_MAP.get(norm, norm)
-    if norm not in ISO3_ALL or norm in NON_LANGS:
+    if norm is None:
         return None
-    return norm
+    resolved = ISO3_MAP.get(norm, norm)
+    if resolved in ISO3_ALL and resolved not in NON_LANGS:
+        return resolved
+    # The full tag takes precedence (the synonym table has entries like
+    # "chi_sim"); only then fall back to the primary subtag.
+    for sep in ("-", "_"):
+        if sep in norm:
+            return iso_639_alpha3(norm.split(sep, 1)[0])
+    return None
 
 
 def iso_639_alpha2(code: str) -> Optional[str]:

--- a/tests/langs/test_codes.py
+++ b/tests/langs/test_codes.py
@@ -23,6 +23,25 @@ def test_alpha3():
     assert iso_639_alpha3("mul") is None
 
 
+def test_alpha3_subtags():
+    # IETF/BCP 47-style tags resolve via their primary subtag:
+    assert iso_639_alpha3("zh-Hans") == "zho"
+    assert iso_639_alpha3("zh-hant") == "zho"
+    assert iso_639_alpha3("pt-BR") == "por"
+    assert iso_639_alpha3("en-gb") == "eng"
+    assert iso_639_alpha3("sr-el") == "srp"
+    assert iso_639_alpha3("be-tarask") == "bel"
+    assert iso_639_alpha3("kk-cyrl") == "kaz"
+    assert iso_639_alpha3("crh-latn") == "crh"
+    # A known full tag wins over subtag splitting (synonym table):
+    assert iso_639_alpha3("chi_sim") == "zho"
+    assert iso_639_alpha3("aze_cyrl") == "aze"
+    # Collective and non-language primary subtags still fail:
+    assert iso_639_alpha3("roa-tara") is None
+    assert iso_639_alpha3("mul-x-foo") is None
+    assert iso_639_alpha2("pt-BR") == "pt"
+
+
 def test_alpha2():
     assert iso_639_alpha2("") is None
     assert iso_639_alpha2("banana") is None


### PR DESCRIPTION
`iso_639_alpha3` only recognized exact two/three-letter codes plus the synonym table, so IETF/BCP 47-style tags carrying a script or region subtag — `zh-Hans`, `pt-BR`, `en-GB`, `sr-el`, `be-tarask`, `kk-Cyrl` — resolved to `None`.

The downstream effect is significant: FtM's `registry.language.clean_text` returns `None` for these tags, and nomenklatura's wikidata `LangText` treats "language given but unmappable" as grounds to drop the **text**, not just the tag. Every Wikidata label/alias tagged with a variant code was silently discarded — notably `zh-hans`/`zh-hant`, the standard codes for Chinese labels — losing name data in a name-matching pipeline (opensanctions/nomenklatura wikidata-module audit, finding #5).

Change: when the full-tag lookup fails, fall back to resolving the primary subtag through the same path. Ordering matters and is preserved — the full tag is tried first, so synonym-table entries like `chi_sim` → `zho` and `aze_cyrl` → `aze` behave exactly as before. Collective or non-language primary subtags (`roa-tara`, `mul-x-foo`) still return `None`, and `iso_639_alpha2` inherits the behavior.

Verified end-to-end through the stack: `registry.language.clean_text("zh-hans")` → `zho`, and a `LangText("普京", "zh-hans")` now retains its text. Full rigour suite passes (514 tests), `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)