### PR TITLE
Fix LangStr hash/eq contract violation with plain str (closes #255)

### DIFF
--- a/rigour/langs/text.py
+++ b/rigour/langs/text.py
@@ -25,7 +25,7 @@ class LangStr(str):
         return super().__repr__()
 
     def __hash__(self) -> int:
-        return hash((super().__str__(), self.lang))
+        return hash(str(self))
 
     def __eq__(self, value: object) -> bool:
         try:

--- a/tests/langs/test_text.py
+++ b/tests/langs/test_text.py
@@ -20,8 +20,53 @@ def test_langstr():
     assert repr(text) == '"Hello"@eng'
 
     assert "Hello" == text
-    assert hash(text) == hash(("Hello", "eng"))
+    assert hash(text) == hash("Hello")
     assert text != LangStr("Hello", lang="deu")
 
     with pytest.raises(ValueError):
         LangStr("Hello", lang="invalid")
+
+
+def test_langstr_hash_eq_contract():
+    """LangStr must satisfy a == b => hash(a) == hash(b) with plain str (#255)."""
+    a = LangStr("foo", "eng")
+    assert a == "foo"
+    assert hash(a) == hash("foo")
+    assert "foo" == a
+    assert hash("foo") == hash(a)
+
+
+def test_langstr_str_keyed_dict():
+    """LangStr lookups in str-keyed dicts must work after the hash fix (#255)."""
+    a = LangStr("foo", "eng")
+    d = {"foo": 1}
+    assert d.get(a) == 1
+    assert a in d
+
+
+def test_langstr_str_keyed_set():
+    """LangStr instances equal to a plain str must deduplicate in sets (#255)."""
+    a = LangStr("foo", "eng")
+    s = {"foo", a}
+    assert len(s) == 1
+    assert "foo" in s
+
+
+def test_langstr_lang_differing():
+    """Two LangStrs with same text but different lang share a hash bucket.
+
+    They are NOT equal (lang differs), but they must hash to the same value
+    since both compare equal to the same plain str — the hash/eq contract
+    requires hash(a) == hash(b) whenever a == c and b == c for a common c.
+    """
+    a = LangStr("foo", "eng")
+    b = LangStr("foo", "deu")
+    assert a != b
+    assert hash(a) == hash(b)
+
+
+def test_langstr_none_lang():
+    """LangStr with None lang still satisfies the hash/eq contract."""
+    a = LangStr("foo", None)
+    assert a == "foo"
+    assert hash(a) == hash("foo")


### PR DESCRIPTION
## Problem

`LangStr.__hash__` returned `hash((text, lang))` but `__eq__` falls back to
value-only comparison with plain `str`. This violates Python's
`a == b => hash(a) == hash(b)` invariant: a `LangStr` that compares equal to a
plain `str` has a different hash, making it unfindable in str-keyed dicts/sets.

Closes #255.

## Reproduction

```python
from rigour.langs.text import LangStr
a = LangStr("foo", "eng")
a == "foo"                      # True
hash(a) == hash("foo")          # False  -- broken
{"foo": 1}.get(a)               # None   -- not found
{"foo", a}                      # 2 elements instead of 1
```

## Root Cause

In `rigour/langs/text.py`, `__hash__` always encodes the `(content, lang)`
tuple, but `__eq__` ignores `lang` when the other operand is a plain `str`.

## Change

```diff
     def __hash__(self) -> int:
-        return hash((super().__str__(), self.lang))
+        return hash(str(self))
```

This follows **Option 1** from the issue: hash like a plain `str`, preserving the
documented "transparent string" behavior. Two `LangStr`s that differ only in
`lang` share a hash bucket (acceptable - equality still separates them).

## Tests

Updated the existing test assertion and added 5 regression tests:
- `test_langstr_hash_eq_contract`: `a == b => hash(a) == hash(b)`
- `test_langstr_str_keyed_dict`: lookup in str-keyed dict works
- `test_langstr_str_keyed_set`: set deduplication works
- `test_langstr_lang_differing`: same text, different lang share hash
- `test_langstr_none_lang`: `None` lang satisfies contract

All 6 lang tests pass.

## Compatibility

- No public API changes
- `__hash__` still returns `int`
- `__eq__` unchanged
- Existing behavior preserved for `LangStr == LangStr` (lang-sensitive)

## Risks

Very low. The fix aligns `__hash__` with the documented promise that LangStr
"behaves like a regular string." Hash collisions between LangStrs with different
languages are benign.

## Out of Scope

- Option 2 (making equality lang-sensitive across the board)
- Any changes to other modules
