### PR TITLE
urls: validate the host before accepting a cleaned URL

### DIFF
--- a/rigour/urls/cleaning.py
+++ b/rigour/urls/cleaning.py
@@ -1,9 +1,19 @@
+import re
+from ipaddress import ip_address
 from typing import Optional
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 from urllib.parse import ParseResult
 from collections.abc import Mapping
 
 from rigour.urls.util import ParamsType, DEFAULT_SCHEME, SCHEMES
+
+# A single host label, capped at the DNS length limit. `\w` matches letters in
+# any script, so a domain is accepted both in its decoded IDN form (`пример.рф`)
+# and as punycode (`xn--e1afmkfd.xn--p1ai`).
+HOST_LABEL = re.compile(r"[\w-]{1,63}", re.UNICODE)
+# A letter or digit in any script, i.e. a label that is not just punctuation.
+HOST_ALNUM = re.compile(r"[^\W_]", re.UNICODE)
+WHITESPACE = re.compile(r"\s")
 
 
 def build_url(url: str, params: ParamsType = None) -> str:
@@ -17,6 +27,42 @@ def build_url(url: str, params: ParamsType = None) -> str:
     return urlunparse(parsed)
 
 
+def _is_valid_netloc(parsed: ParseResult) -> bool:
+    """Check that the authority of a parsed URL is a plausible host name.
+
+    `urlparse` accepts everything up to the first slash as the authority, so it
+    never rejects free text: a label someone typed into a spreadsheet's website
+    column ("Social media: http://vk.com/x") parses as a URL whose host is that
+    prose. Screening the host is what keeps such values from being emitted as
+    URLs that merely look well-formed.
+    """
+    if WHITESPACE.search(parsed.netloc) is not None:
+        return False
+    try:
+        host = parsed.hostname
+        _ = parsed.port  # raises for a non-numeric or out-of-range port
+    except ValueError:
+        return False
+    if host is None or len(host) == 0:
+        return False
+    try:
+        ip_address(host)
+        return True
+    except ValueError:
+        pass
+    labels = host.rstrip(".").split(".")
+    for label in labels:
+        if HOST_LABEL.fullmatch(label) is None:
+            return False
+        if HOST_ALNUM.search(label) is None:
+            return False
+    # No public suffix is a single character or all digits, so this rejects
+    # decimals and abbreviations read as host names ("3.4", "N.A.").
+    if len(labels) > 1 and (len(labels[-1]) < 2 or labels[-1].isdigit()):
+        return False
+    return True
+
+
 def _clean_url(text: str) -> Optional[ParseResult]:
     """Perform intensive care on URLs to make sure they have a scheme
     and a host name. If no scheme is given HTTP is assumed."""
@@ -25,11 +71,18 @@ def _clean_url(text: str) -> Optional[ParseResult]:
     except (TypeError, ValueError):  # pragma: no cover
         return None
     if not len(parsed.netloc):
+        # A supported scheme with no authority is a URL this function cannot
+        # handle (`mailto:`, `file:`) or a mangled one (`https:example.com`).
+        # Bail out before the rule below invents a host name from the path.
+        if parsed.scheme.lower() in SCHEMES:
+            return None
         if "." in parsed.path and not text.startswith("//"):
             # This is a pretty weird rule meant to catch things like
             # 'www.google.com', but it'll likely backfire in some
             # really creative ways.
             return _clean_url(f"//{text}")
+        return None
+    if not _is_valid_netloc(parsed):
         return None
     if not len(parsed.scheme):
         parsed = parsed._replace(scheme=DEFAULT_SCHEME)

--- a/tests/urls/test_cleaning.py
+++ b/tests/urls/test_cleaning.py
@@ -14,6 +14,71 @@ def test_clean_url():
     assert clean_url("https://www.google.com/?q=foo&bar=baz") == "https://www.google.com/?q=foo&bar=baz"
     
 
+def test_clean_url_junk_host():
+    # Free text pasted into a website column: urlparse reads the prose as the
+    # authority, so without a host check these come back as bogus URLs.
+    assert clean_url("Social media: http://vk.com/sobolipress") is None
+    assert clean_url("Official web site: http://soboli.net") is None
+    assert clean_url("Website: www.example.com") is None
+    assert clean_url("see the report on page 3.4 for details") is None
+    assert clean_url("ул. Ленина, д. 5") is None
+    assert clean_url("foo bar.baz qux") is None
+    assert clean_url("http://exa mple.com/") is None
+    assert clean_url("http://exa,mple.com/") is None
+    assert clean_url("http://<none>/") is None
+    # Values that only look like host names because they contain a dot.
+    assert clean_url("3.4") is None
+    assert clean_url("Nr. 12.5") is None
+    assert clean_url("N.A.") is None
+    assert clean_url("n/a") is None
+
+
+def test_clean_url_idn():
+    assert clean_url("русскоедвижение.рф") == "http://русскоедвижение.рф/"
+    assert clean_url("http://www.русскоедвижение.рф/") == "http://www.русскоедвижение.рф/"
+    assert clean_url("例え.テスト") == "http://例え.テスト/"
+    assert clean_url("https://عربي.مصر") == "https://عربي.مصر/"
+    assert clean_url("https://пример.рф/путь?q=да") == "https://пример.рф/путь?q=да"
+    # The punycode encoding of the same domains must survive unchanged.
+    assert clean_url("xn--80aa.xn--p1ai") == "http://xn--80aa.xn--p1ai/"
+    assert clean_url("http://xn--e1afmkfd.xn--p1ai/path") == "http://xn--e1afmkfd.xn--p1ai/path"
+    assert clean_url("XN--80AA.XN--P1AI") == "http://XN--80AA.XN--P1AI/"
+
+
+def test_clean_url_authority():
+    assert clean_url("https://user:pw@example.com:8443/x") == "https://user:pw@example.com:8443/x"
+    assert clean_url("https://user@example.com/x") == "https://user@example.com/x"
+    assert clean_url("http://192.168.0.1:8080/x") == "http://192.168.0.1:8080/x"
+    assert clean_url("http://[2001:db8::1]/x") == "http://[2001:db8::1]/x"
+    assert clean_url("http://[::1]:8000/") == "http://[::1]:8000/"
+    assert clean_url("http://localhost:8000/") == "http://localhost:8000/"
+    assert clean_url("http://example.com./") == "http://example.com./"
+    assert clean_url("http://example.com:99999/") is None
+    assert clean_url("http://example.com:port/") is None
+    assert clean_url("http://:8080/") is None
+    assert clean_url("http://user@/x") is None
+
+
+def test_clean_url_labels():
+    assert clean_url("example.co") == "http://example.co/"
+    assert clean_url("http://ex-ample.co.uk/") == "http://ex-ample.co.uk/"
+    assert clean_url("http://my_host.example.com/") == "http://my_host.example.com/"
+    assert clean_url("http://foo..com/") is None
+    assert clean_url("http://%s.com/" % ("a" * 64)) is None
+    assert clean_url("http://./") is None
+    assert clean_url("http://-/") is None
+    assert clean_url("1.2.3.4.5.6") is None
+
+
+def test_clean_url_scheme_without_host():
+    # A supported scheme with no authority used to have a host invented from
+    # its path, e.g. 'mailto:foo@bar.com' -> 'http://mailto:foo@bar.com/'.
+    assert clean_url("mailto:foo@bar.com") is None
+    assert clean_url("file:///tmp/foo.txt") is None
+    assert clean_url("https:www.example.com") is None
+    assert clean_url("s3://bucket/key.txt") == "s3://bucket/key.txt"
+
+
 def test_clean_url_compare():
     assert clean_url_compare("") is None
     assert clean_url_compare("!!@@@@") is None


### PR DESCRIPTION
Fixes the broken `website` values reported in opensanctions/followthemoney#339.

## The bug

`urlparse` treats everything up to the first slash as the authority and never rejects free text, so `_clean_url` accepted whatever landed there. A label someone typed into a spreadsheet's website column came back as a URL that looks well-formed:

```python
clean_url("Social media: http://vk.com/sobolipress")
# -> 'http://Social media: http://vk.com/sobolipress'
```

The `"." in parsed.path` heuristic made this reachable for any text containing a dot — the existing comment ("it'll likely backfire in some really creative ways") was right:

```python
clean_url("see the report on page 3.4 for details")  # -> 'http://see the report on page 3.4 for details/'
clean_url("ул. Ленина, д. 5")                        # -> 'http://ул. Ленина, д. 5/'
clean_url("3.4")                                     # -> 'http://3.4/'
```

## The change

`_is_valid_netloc()` screens the authority: no whitespace; `hostname` and `port` must be extractable; IP literals accepted via `ipaddress`; otherwise every label must match `[\w-]{1,63}` and contain at least one alphanumeric, and a dotted host's final label must be at least two characters and not all digits.

Host labels use a unicode character class, so a domain is accepted both decoded and as punycode — `русскоедвижение.рф` and `xn--e1afmkfd.xn--p1ai`, uppercase included. Userinfo, ports, IPv4/IPv6 literals, bare `localhost`, trailing-dot FQDNs and underscored hosts are unaffected.

Separately, a supported scheme with an empty authority now bails out instead of falling through to the dot heuristic, which used to invent a host from the path:

```python
clean_url("mailto:foo@bar.com")   # was 'http://mailto:foo@bar.com/',    now None
clean_url("file:///tmp/foo.txt")  # was 'http://file:///tmp/foo.txt',    now None
```

Neither scheme is really supported; returning `None` beats emitting nonsense. Real `mailto:` support would need its own branch and is left for later.

## Compatibility

This is a behaviour change: values that previously cleaned successfully now return `None`. Everything in that set was already being emitted as a broken URL, so downstream data loses garbage rather than anything usable — but it is worth a minor version bump rather than a patch.

One case from the issue is deliberately **not** fixed: `"vk.com/sobolipress; http://www.русскоедвижение.рф/"` still passes, because `vk.com` is a genuinely valid host and the second URL rides along in the path. Splitting multi-value strings belongs in the crawlers, not here.

## Tests

Five new test functions covering junk hosts, IDN in both encodings, authority forms, label rules, and schemes without a host. Existing assertions are untouched. `rigour/urls/cleaning.py` is at 100% statement and branch coverage.

- rigour: 513 passed, `mypy --strict` clean
- followthemoney: 304 passed (one pre-existing test needed a fix, see below)
- nomenklatura: 316 passed

`followthemoney`'s `test_unicode_url` asserted that `quote(url)` with the default `safe="/"` validates. That percent-encodes the scheme colon into `http%3A//ko.wikipedia.org/...`, which the old code "repaired" into a URL whose host was `http%3A`. It needs `quote(url, safe=":/")` — a one-line change I'll send as a followthemoney PR alongside the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)