### PR TITLE
Make LangStr identity hinge on the language tag

### DIFF
--- a/rigour/langs/text.py
+++ b/rigour/langs/text.py
@@ -1,4 +1,3 @@
-
 from typing import TypeVar
 
 from rigour.data.langs.iso639 import ISO3_ALL
@@ -7,9 +6,30 @@ LangStrT = TypeVar("LangStrT", bound="LangStr")
 
 
 class LangStr(str):
-    """A type of string that include language metadata. This is useful for handling multilingual content.
+    """A string carrying an optional language tag.
 
-    The class does not override any operators and functions, which means they will behave like a regular string.
+    Use this to keep track of which language a piece of multilingual
+    content is written in while still passing it around as a `str`.
+
+    The language tag is part of the value's identity:
+
+    * With no tag (`lang is None`), a `LangStr` is indistinguishable from
+      its content string: it compares equal to the plain `str`, hashes the
+      same, and deduplicates against it in sets and dict keys.
+    * With a tag, a `LangStr` is a distinct value identified by the pair
+      `(content, lang)`. It is not equal to the bare content string, nor
+      to a `LangStr` with a different or missing tag, and it never
+      deduplicates against them.
+
+    Ordinary `str` methods (`.upper()`, slicing, concatenation, …) return
+    plain `str` and drop the tag.
+
+    Args:
+        content: The text.
+        lang: An ISO 639-3 language code, or `None` for untagged text.
+
+    Raises:
+        ValueError: If `lang` is not a known ISO 639-3 code.
     """
 
     __slots__ = ("lang",)
@@ -30,13 +50,18 @@ class LangStr(str):
         return super().__repr__()
 
     def __hash__(self) -> int:
+        if self.lang is None:
+            return super().__hash__()
         return hash((super().__str__(), self.lang))
 
     def __eq__(self, value: object) -> bool:
-        try:
-            return super().__eq__(value) and self.lang == value.lang  # type: ignore
-        except AttributeError:
-            return super().__eq__(value)
+        if not isinstance(value, str):
+            return NotImplemented
+        other_lang = value.lang if isinstance(value, LangStr) else None
+        return super().__eq__(value) and self.lang == other_lang
 
     def __ne__(self, value: object) -> bool:
-        return not self.__eq__(value)
+        equal = self.__eq__(value)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not equal

--- a/tests/langs/test_text.py
+++ b/tests/langs/test_text.py
@@ -4,24 +4,74 @@ from rigour.langs.text import LangStr
 
 
 def test_langstr():
-    # Test creation without language
     text = LangStr("Hello")
     assert text == "Hello"
     assert text.lang is None
     assert repr(text) == repr("Hello")
 
-    # Test creation with language
     text = LangStr("Hello", lang="eng")
-    assert text == "Hello"
     assert text.lang == "eng"
-
-    # Test representation
-    text = LangStr("Hello", lang="eng")
     assert repr(text) == '"Hello"@eng'
-
-    assert "Hello" == text
-    assert hash(text) == hash(("Hello", "eng"))
-    assert text != LangStr("Hello", lang="deu")
+    assert str(text) == "Hello"
 
     with pytest.raises(ValueError):
         LangStr("Hello", lang="invalid")
+
+
+def test_untagged_behaves_like_str():
+    text = LangStr("foo")
+    assert text == "foo"
+    assert "foo" == text
+    assert (text != "foo") is False
+    assert hash(text) == hash("foo")
+    assert {"foo": 1}.get(text) == 1
+    assert text in {"foo"}
+    assert len({"foo", text}) == 1
+    assert len({text, "foo"}) == 1
+    assert text == LangStr("foo")
+    assert hash(text) == hash(LangStr("foo"))
+
+
+def test_tagged_is_distinct_from_str():
+    text = LangStr("foo", "eng")
+    assert text != "foo"
+    assert "foo" != text
+    assert (text == "foo") is False
+    assert ("foo" == text) is False
+    assert {"foo": 1}.get(text) is None
+    assert text not in {"foo"}
+    assert len({"foo", text}) == 2
+
+
+def test_tagged_identity_is_content_and_lang():
+    eng = LangStr("foo", "eng")
+    assert eng == LangStr("foo", "eng")
+    assert hash(eng) == hash(LangStr("foo", "eng"))
+    assert eng != LangStr("foo", "deu")
+    assert eng != LangStr("bar", "eng")
+    assert eng != LangStr("foo")
+    assert LangStr("foo") != eng
+    assert {LangStr("foo", "eng"): 1}.get(eng) == 1
+    assert {LangStr("foo", "deu"): 1}.get(eng) is None
+
+
+def test_set_dedup_is_order_independent():
+    eng = LangStr("foo", "eng")
+    deu = LangStr("foo", "deu")
+    assert len({"foo", eng, deu}) == 3
+    assert len({eng, deu, "foo"}) == 3
+    assert len({deu, "foo", eng}) == 3
+    assert len({LangStr("foo"), "foo", eng}) == 2
+
+
+def test_non_str_operands():
+    class Tagged:
+        lang = "eng"
+
+    text = LangStr("foo", "eng")
+    assert text != 1
+    assert text != None
+    assert text != Tagged()
+    assert (text == Tagged()) is False
+    assert LangStr("foo") != 1
+    assert LangStr("foo") != b"foo"


### PR DESCRIPTION
Closes #255. Supersedes #261.

## Problem

`LangStr` compared equal to a plain `str` by content but hashed on `(content, lang)`, so `LangStr("foo", "eng") == "foo"` was True while the hashes differed. Str-keyed dict and set lookups silently missed.

#261 fixed the hash by using `hash(str(self))` but kept lang-sensitive equality between two `LangStr`s. That leaves equality non-transitive: `"foo" == a`, `"foo" == b`, but `a != b` for `a = LangStr("foo", "eng")`, `b = LangStr("foo", "deu")`. Set deduplication then depends on insertion order: `{"foo", a, b}` has one element, `{a, b, "foo"}` has two.

## Semantics

Identity hinges on the language tag:

- **No tag** (`lang is None`): the `LangStr` is indistinguishable from its content string. Equal both ways, same hash, dedupes against the plain `str`.
- **Tagged**: the `LangStr` is a distinct value identified by `(content, lang)`. Not equal to the bare string, nor to a `LangStr` with a different or missing tag. Hash is `hash((content, lang))`.

A bare `str` is treated as `lang=None`, which makes equality a proper equivalence relation. Non-`str` operands now get `NotImplemented` instead of the old attribute-error fallback, which accepted any object carrying a `.lang` attribute.

## Behaviour change

`"Hello" == LangStr("Hello", lang="eng")` flips from True to False. The only downstream consumer is `caption` in followthemoney's statement entity, which passes `LangStr`s straight to `pick_lang_name`; that reads `.lang` and calls `str()` only. followthemoney's `tests/statement` pass against this branch.

## Verification

- `pytest tests` (520 passed), `mypy --strict rigour`, `mkdocs build --strict`
- New tests cover both equality directions, str-keyed dict/set lookups, order-independent dedup, and non-str operands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)