### PR TITLE
Add match_addresses returning the winning address pair with alignment detail

### DIFF
--- a/rigour/_core.pyi
+++ b/rigour/_core.pyi
@@ -13,6 +13,7 @@ def raw_jaro(a: str, b: str) -> float: ...
 def raw_jaro_winkler(a: str, b: str) -> float: ...
 def compare_address(query: str, result: str) -> float: ...
 def compare_address_many(queries: list[str], results: list[str]) -> float: ...
+def match_addresses(queries: list[str], results: list[str]) -> AddressMatch | None: ...
 def address_fingerprint(text: str) -> str | None: ...
 def pick_name(names: list[str]) -> str | None: ...
 def pick_case(names: list[str]) -> str | None: ...
@@ -40,6 +41,26 @@ def territories_jsonl() -> str: ...
 
 MAX_NAME_LENGTH: int
 
+
+class AddressMatch:
+    """The best pair out of a list×list address comparison, with the
+    evidence that produced it. Frozen; all attributes are read-only.
+    """
+
+    score: float
+    """Similarity of the winning pair in [0.0, 1.0]."""
+    query: str
+    """Query-side address of the winning pair, as supplied."""
+    result: str
+    """Result-side address of the winning pair, as supplied."""
+    detail: str
+    """One-line alignment summary over comparable token forms:
+    aligned tokens in query order (`berlin` when identical,
+    `boulevard~blvd` when aligned by edit distance or class
+    equivalence), then `-tok` for query-only and `+tok` for
+    result-only tokens."""
+
+    def __repr__(self) -> str: ...
 
 class SymbolCategory:
     """Sealed enum of symbol categories. See

--- a/rigour/addresses/__init__.py
+++ b/rigour/addresses/__init__.py
@@ -9,14 +9,19 @@ Score whether two address strings (or two sets of them) denote the
 same place:
 
 ```python
-from rigour.addresses import compare_address, compare_address_many
+from rigour.addresses import compare_address, match_addresses
 
 score = compare_address("Bahnhofstr. 10, Augsburg", "Bahnhofstrasse 10, 86150 Augsburg")
-best = compare_address_many(
-    ["Bahnhofstr. 10, Augsburg"],
-    ["Bahnhofstrasse 10, 86150 Augsburg", "P.O. Box 71, Augsburg"],
+match = match_addresses(
+    ["Bahnhofstrasse 10, Augsburg"],
+    ["Bahnhofstrase 10, 86150 Augsburg", "P.O. Box 71, Augsburg"],
 )
+# match.result == "Bahnhofstrase 10, 86150 Augsburg"
+# match.detail == "bahnhofstrasse~bahnhofstrase 10 augsburg +86150"
 ```
+
+[compare_address_many][rigour.addresses.compare.compare_address_many]
+is the same pairing returning only the score.
 
 The comparison runs in native code over analyzed tokens — see
 [compare_address][rigour.addresses.compare.compare_address] for the
@@ -63,9 +68,11 @@ format addresses according to customs in the country that is been encoded.
 
 from rigour.addresses.cleaning import clean_address
 from rigour.addresses.compare import (
+    AddressMatch,
     address_fingerprint,
     compare_address,
     compare_address_many,
+    match_addresses,
 )
 from rigour.addresses.format import format_address, format_address_line
 from rigour.addresses.normalize import (
@@ -75,12 +82,14 @@ from rigour.addresses.normalize import (
 )
 
 __all__ = [
+    "AddressMatch",
     "address_fingerprint",
     "clean_address",
     "compare_address",
     "compare_address_many",
     "format_address",
     "format_address_line",
+    "match_addresses",
     "normalize_address",
     "remove_address_keywords",
     "shorten_address_keywords",

--- a/rigour/addresses/compare.py
+++ b/rigour/addresses/compare.py
@@ -1,10 +1,18 @@
 """Compare postal address strings for referring to the same place."""
 
+from rigour._core import AddressMatch
 from rigour._core import address_fingerprint as _address_fingerprint
 from rigour._core import compare_address as _compare_address
 from rigour._core import compare_address_many as _compare_address_many
+from rigour._core import match_addresses as _match_addresses
 
-__all__ = ["address_fingerprint", "compare_address", "compare_address_many"]
+__all__ = [
+    "AddressMatch",
+    "address_fingerprint",
+    "compare_address",
+    "compare_address_many",
+    "match_addresses",
+]
 
 
 def compare_address(query: str, result: str) -> float:
@@ -51,12 +59,9 @@ def compare_address_many(queries: list[str], results: list[str]) -> float:
     """Compare two sets of address strings and return the best
     pairwise score.
 
-    Scores every query against every result with
-    [compare_address][rigour.addresses.compare.compare_address] and
-    returns the maximum — the natural shape for matching two
-    entities that each carry several address renderings. Each
-    distinct string is analyzed only once, so the list×list loop is
-    substantially cheaper than the equivalent pairwise calls.
+    The score-only form of
+    [match_addresses][rigour.addresses.compare.match_addresses]:
+    same pairing, same analysis cache, without the match object.
 
     Args:
         queries: Addresses of one entity, each as one full string.
@@ -68,6 +73,47 @@ def compare_address_many(queries: list[str], results: list[str]) -> float:
         0.0 when either list is empty or nothing is comparable.
     """
     return _compare_address_many(queries, results)
+
+
+def match_addresses(queries: list[str], results: list[str]) -> AddressMatch | None:
+    """Compare two sets of address strings and return the best
+    pairwise match with the evidence behind it.
+
+    Scores every query against every result with
+    [compare_address][rigour.addresses.compare.compare_address] and
+    returns the winning pair as an
+    [AddressMatch][rigour._core.AddressMatch]: its `score`, the two
+    input strings that produced it (`query`, `result`), and a
+    one-line `detail` describing how the tokens aligned. Each
+    distinct string is analyzed only once, so the list×list loop is
+    substantially cheaper than the equivalent pairwise calls.
+
+    The `detail` line lists analyzed tokens (lowercased, narrowly
+    transliterated) separated by spaces: aligned tokens first, in
+    query order, then the leftovers of each side.
+
+    | form | meaning |
+    |---|---|
+    | `berlin` | aligned, identical on both sides |
+    | `boulevard~blvd` | aligned by edit distance, keyword alias or territory code (query left, result right) |
+    | `-10115` | only in the query address |
+    | `+la` | only in the result address |
+
+    A line without `~`, `-` or `+` is an exact match; leftovers on
+    one side only mark a subset relation; a `-5 +7` pair of numbers
+    is the penalized house- or unit-number conflict.
+
+    Args:
+        queries: Addresses of one entity, each as one full string.
+        results: Addresses of the other entity, each as one full
+            string.
+
+    Returns:
+        The best-scoring pair, or `None` when either list is empty or
+        contains nothing analyzable (only punctuation). A pair with
+        nothing in common is still returned, with a score of 0.0.
+    """
+    return _match_addresses(queries, results)
 
 
 def address_fingerprint(text: str) -> str | None:

--- a/rust/src/addresses/compare.rs
+++ b/rust/src/addresses/compare.rs
@@ -5,7 +5,13 @@
 // greedy best-pair token alignment over analyzed tokens, scored by
 // length-weighted edit-distance similarity.
 
-use crate::addresses::analyze::analyze_cached;
+use std::mem;
+use std::sync::Arc;
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+use crate::addresses::analyze::{Address, analyze_cached};
 use crate::addresses::token::{AddressToken, TokenClass};
 use crate::text::distance::levenshtein_cutoff;
 
@@ -25,37 +31,161 @@ const ALIAS_SIM: f64 = 0.90;
 /// than the plain residue weight of two short tokens.
 const NUMBER_MISMATCH_PENALTY: f64 = 0.7;
 
+/// One accepted token alignment: query index, result index,
+/// similarity.
+type Bound = (usize, usize, f64);
+
+/// The best pair out of a list×list address comparison, with the
+/// evidence that produced it.
+#[cfg_attr(
+    feature = "python",
+    pyclass(frozen, get_all, skip_from_py_object, module = "rigour._core")
+)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddressMatch {
+    /// Similarity of the winning pair in [0.0, 1.0].
+    pub score: f64,
+    /// Query-side address of the winning pair, as supplied.
+    pub query: String,
+    /// Result-side address of the winning pair, as supplied.
+    pub result: String,
+    /// One-line alignment summary over comparable token forms:
+    /// aligned tokens in query order (`berlin` when identical,
+    /// `boulevard~blvd` when aligned by edit distance or class
+    /// equivalence), then `-tok` for query-only and `+tok` for
+    /// result-only tokens.
+    pub detail: String,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AddressMatch {
+    fn __repr__(&self) -> String {
+        format!(
+            "AddressMatch(score={:.3}, query={:?}, result={:?}, detail={:?})",
+            self.score, self.query, self.result, self.detail
+        )
+    }
+}
+
 /// Compare two address strings, returning a similarity in [0.0, 1.0].
 pub fn compare(query: &str, result: &str) -> f64 {
-    let Some(qry) = analyze_cached(query) else {
-        return 0.0;
-    };
-    let Some(res) = analyze_cached(result) else {
-        return 0.0;
-    };
-    align_tokens(&qry.tokens, &res.tokens)
+    compare_many(&[query], &[result])
 }
 
 /// Compare every query address against every result address and
 /// return the highest pairwise score. Each string is analyzed once
 /// (through the LRU), so the list×list loop costs analysis per
 /// distinct string plus one alignment per pair.
-pub fn compare_many(queries: &[String], results: &[String]) -> f64 {
-    let qry: Vec<_> = queries.iter().filter_map(|s| analyze_cached(s)).collect();
-    let res: Vec<_> = results.iter().filter_map(|s| analyze_cached(s)).collect();
-    let mut best: f64 = 0.0;
-    for q in &qry {
-        for r in &res {
-            let score = align_tokens(&q.tokens, &r.tokens);
-            if score > best {
-                best = score;
-                if best >= 1.0 {
-                    return best;
+pub fn compare_many<S: AsRef<str>>(queries: &[S], results: &[S]) -> f64 {
+    let qry = analyze_all(queries);
+    let res = analyze_all(results);
+    best_pair(&qry, &res).map_or(0.0, |b| b.score)
+}
+
+/// Compare every query address against every result address and
+/// return the best pair with its alignment detail, or `None` when
+/// either side holds nothing analyzable.
+pub fn match_many<S: AsRef<str>>(queries: &[S], results: &[S]) -> Option<AddressMatch> {
+    let qry = analyze_all(queries);
+    let res = analyze_all(results);
+    let best = best_pair(&qry, &res)?;
+    let (query, qaddr) = &qry[best.qi];
+    let (result, raddr) = &res[best.ri];
+    Some(AddressMatch {
+        score: best.score,
+        query: query.to_string(),
+        result: result.to_string(),
+        detail: describe(&qaddr.tokens, &raddr.tokens, &best.bound),
+    })
+}
+
+/// Winning pair of a list×list comparison.
+struct Best {
+    score: f64,
+    qi: usize,
+    ri: usize,
+    bound: Vec<Bound>,
+}
+
+fn analyze_all<S: AsRef<str>>(texts: &[S]) -> Vec<(&str, Arc<Address>)> {
+    texts
+        .iter()
+        .map(AsRef::as_ref)
+        .filter_map(|s| analyze_cached(s).map(|a| (s, a)))
+        .collect()
+}
+
+/// Score every pair and keep the best. The alignment writes its
+/// bound pairs into one scratch buffer that is swapped into the
+/// winner's slot on improvement, so the loop allocates nothing per
+/// pair beyond the alignment's own candidate list.
+fn best_pair(qry: &[(&str, Arc<Address>)], res: &[(&str, Arc<Address>)]) -> Option<Best> {
+    let mut best: Option<Best> = None;
+    let mut scratch: Vec<Bound> = Vec::new();
+    for (qi, (_, q)) in qry.iter().enumerate() {
+        for (ri, (_, r)) in res.iter().enumerate() {
+            let score = align_tokens(&q.tokens, &r.tokens, &mut scratch);
+            let improved = best.as_ref().is_none_or(|b| score > b.score);
+            if !improved {
+                continue;
+            }
+            match best.as_mut() {
+                Some(b) => {
+                    b.score = score;
+                    b.qi = qi;
+                    b.ri = ri;
+                    mem::swap(&mut b.bound, &mut scratch);
                 }
+                None => {
+                    best = Some(Best {
+                        score,
+                        qi,
+                        ri,
+                        bound: mem::take(&mut scratch),
+                    });
+                }
+            }
+            if score >= 1.0 {
+                return best;
             }
         }
     }
     best
+}
+
+/// Render the alignment as one line: aligned tokens in query order
+/// (`tok` when both comparable forms agree, `q~r` otherwise), then
+/// `-tok` for unmatched query tokens and `+tok` for unmatched result
+/// tokens.
+fn describe(qry: &[AddressToken], res: &[AddressToken], bound: &[Bound]) -> String {
+    let mut ordered: Vec<&Bound> = bound.iter().collect();
+    ordered.sort_by_key(|b| b.0);
+    let mut qry_used = vec![false; qry.len()];
+    let mut res_used = vec![false; res.len()];
+    let mut parts: Vec<String> = Vec::with_capacity(qry.len() + res.len());
+    for &&(qi, ri, _) in &ordered {
+        qry_used[qi] = true;
+        res_used[ri] = true;
+        let q = qry[qi].comparable();
+        let r = res[ri].comparable();
+        if q == r {
+            parts.push(q.to_string());
+        } else {
+            parts.push(format!("{q}~{r}"));
+        }
+    }
+    for (tok, used) in qry.iter().zip(&qry_used) {
+        if !used {
+            parts.push(format!("-{}", tok.comparable()));
+        }
+    }
+    for (tok, used) in res.iter().zip(&res_used) {
+        if !used {
+            parts.push(format!("+{}", tok.comparable()));
+        }
+    }
+    parts.join(" ")
 }
 
 /// Similarity of two tokens in [0.0, 1.0]. Two Number tokens match
@@ -112,8 +242,10 @@ fn token_similarity(a: &str, b: &str) -> f64 {
 /// Greedy best-pair alignment: the highest-similarity pair binds
 /// first, each token aligns at most once. The score is the
 /// similarity-discounted matched weight over the total weight of
-/// both sides, with token weight proportional to length.
-fn align_tokens(qry: &[AddressToken], res: &[AddressToken]) -> f64 {
+/// both sides, with token weight proportional to length. The
+/// accepted pairs are written to `bound` (cleared first).
+fn align_tokens(qry: &[AddressToken], res: &[AddressToken], bound: &mut Vec<Bound>) -> f64 {
+    bound.clear();
     let total: usize = qry
         .iter()
         .chain(res.iter())
@@ -143,6 +275,7 @@ fn align_tokens(qry: &[AddressToken], res: &[AddressToken]) -> f64 {
         }
         qry_used[qi] = true;
         res_used[ri] = true;
+        bound.push((qi, ri, sim));
         let weight = qry[qi].comparable().chars().count() + res[ri].comparable().chars().count();
         matched += sim * weight as f64;
     }
@@ -171,6 +304,10 @@ fn unmatched_pairs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn detail(query: &str, result: &str) -> String {
+        match_many(&[query], &[result]).unwrap().detail
+    }
 
     #[test]
     fn identical_scores_one() {
@@ -301,5 +438,67 @@ mod tests {
         assert_eq!(compare("", "Bahnhofstr. 12"), 0.0);
         assert_eq!(compare("...", "Bahnhofstr. 12"), 0.0);
         assert_eq!(compare("", ""), 0.0);
+    }
+
+    #[test]
+    fn match_many_returns_winning_raw_pair() {
+        let queries = ["Calle Mayor 3, Madrid", "Bahnhofstr. 12, Berlin"];
+        let results = ["10115 Berlin, Bahnhofstrasse 12", "Bahnhofstr. 12, Berlin"];
+        let m = match_many(&queries, &results).unwrap();
+        assert_eq!(m.score, 1.0);
+        assert_eq!(m.query, "Bahnhofstr. 12, Berlin");
+        assert_eq!(m.result, "Bahnhofstr. 12, Berlin");
+        assert_eq!(m.detail, "bahnhofstr 12 berlin");
+        assert_eq!(m.score, compare_many(&queries, &results));
+    }
+
+    #[test]
+    fn match_many_none_without_analyzable_side() {
+        assert!(match_many(&["Bahnhofstr. 12"], &[]).is_none());
+        assert!(match_many::<&str>(&[], &[]).is_none());
+        assert!(match_many(&["..."], &["Bahnhofstr. 12"]).is_none());
+    }
+
+    #[test]
+    fn match_many_zero_score_still_reports_pair() {
+        let m = match_many(&["Bahnhofstr. 12, Berlin"], &["Calle Mayor 3, Madrid"]).unwrap();
+        assert!(m.score < 0.2, "got {}", m.score);
+        assert!(m.detail.starts_with('-'), "got {}", m.detail);
+        assert!(m.detail.contains("+calle"), "got {}", m.detail);
+    }
+
+    #[test]
+    fn detail_marks_alias_and_residue() {
+        assert_eq!(
+            detail("Sunset Boulevard 12, Los Angeles", "Sunset Blvd 12, LA"),
+            "sunset boulevard~blvd 12 -los -angeles +la"
+        );
+    }
+
+    #[test]
+    fn detail_marks_fuzzy_pair() {
+        assert_eq!(
+            detail("Bahnhofstrasse 12, Berlin", "Bahnhofstrase 12, Berlin"),
+            "bahnhofstrasse~bahnhofstrase 12 berlin"
+        );
+    }
+
+    #[test]
+    fn detail_shows_number_conflict_as_residue() {
+        assert_eq!(
+            detail("Hauptstr. 5, 10115 Berlin", "Hauptstr. 7, 10115 Berlin"),
+            "hauptstr 10115 berlin -5 +7"
+        );
+    }
+
+    #[test]
+    fn detail_orders_aligned_by_query() {
+        assert_eq!(
+            detail(
+                "Bahnhofstr. 12, 10115 Berlin",
+                "10115 Berlin, Bahnhofstr. 12"
+            ),
+            "bahnhofstr 12 10115 berlin"
+        );
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -130,6 +130,17 @@ fn py_compare_address_many(py: Python<'_>, queries: Vec<String>, results: Vec<St
 
 #[cfg(feature = "python")]
 #[pyfunction]
+#[pyo3(name = "match_addresses")]
+fn py_match_addresses(
+    py: Python<'_>,
+    queries: Vec<String>,
+    results: Vec<String>,
+) -> Option<addresses::compare::AddressMatch> {
+    py.detach(|| addresses::compare::match_many(&queries, &results))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
 #[pyo3(name = "address_fingerprint")]
 fn py_address_fingerprint(py: Python<'_>, text: &str) -> Option<String> {
     py.detach(|| addresses::fingerprint::fingerprint(text))
@@ -312,6 +323,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_raw_jaro_winkler, m)?)?;
     m.add_function(wrap_pyfunction!(py_compare_address, m)?)?;
     m.add_function(wrap_pyfunction!(py_compare_address_many, m)?)?;
+    m.add_function(wrap_pyfunction!(py_match_addresses, m)?)?;
     m.add_function(wrap_pyfunction!(py_address_fingerprint, m)?)?;
     m.add_function(wrap_pyfunction!(py_pick_name, m)?)?;
     m.add_function(wrap_pyfunction!(py_pick_case, m)?)?;
@@ -337,6 +349,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(names::pairing::py_pair_symbols, m)?)?;
     m.add_function(wrap_pyfunction!(names::compare::py_compare_parts, m)?)?;
+    m.add_class::<addresses::compare::AddressMatch>()?;
     m.add_class::<names::compare::CompareConfig>()?;
     m.add_class::<names::alignment::Alignment>()?;
     m.add_class::<names::symbol::Symbol>()?;

--- a/tests/addresses/test_compare.py
+++ b/tests/addresses/test_compare.py
@@ -1,7 +1,9 @@
 from rigour.addresses import (
+    AddressMatch,
     address_fingerprint,
     compare_address,
     compare_address_many,
+    match_addresses,
 )
 
 
@@ -76,3 +78,39 @@ def test_address_fingerprint_native_script_passthrough() -> None:
 def test_address_fingerprint_empty() -> None:
     assert address_fingerprint("") is None
     assert address_fingerprint(" ,,, --- ") is None
+
+
+def test_match_addresses_returns_winning_pair() -> None:
+    queries = ["Calle Mayor 3, Madrid", "Bahnhofstr. 12, Berlin"]
+    results = ["10115 Berlin, Bahnhofstrasse 12", "Bahnhofstr. 12, Berlin"]
+    match = match_addresses(queries, results)
+    assert match is not None
+    assert isinstance(match, AddressMatch)
+    assert match.score == 1.0
+    assert match.query == "Bahnhofstr. 12, Berlin"
+    assert match.result == "Bahnhofstr. 12, Berlin"
+    assert match.detail == "bahnhofstr 12 berlin"
+    assert match.score == compare_address_many(queries, results)
+    assert repr(match).startswith("AddressMatch(score=1.000, ")
+
+
+def test_match_addresses_detail_grammar() -> None:
+    match = match_addresses(["Sunset Boulevard 12, Los Angeles"], ["Sunset Blvd 12, LA"])
+    assert match is not None
+    assert match.detail == "sunset boulevard~blvd 12 -los -angeles +la"
+    match = match_addresses(["Bahnhofstrasse 12, Berlin"], ["Bahnhofstrase 12, Berlin"])
+    assert match is not None
+    assert match.detail == "bahnhofstrasse~bahnhofstrase 12 berlin"
+    match = match_addresses(["Hauptstr. 5, 10115 Berlin"], ["Hauptstr. 7, 10115 Berlin"])
+    assert match is not None
+    assert match.detail == "hauptstr 10115 berlin -5 +7"
+
+
+def test_match_addresses_none_and_zero() -> None:
+    assert match_addresses([], ["Bahnhofstr. 12"]) is None
+    assert match_addresses(["Bahnhofstr. 12"], []) is None
+    assert match_addresses(["..."], ["Bahnhofstr. 12"]) is None
+    match = match_addresses(["Bahnhofstr. 12, Berlin"], ["Calle Mayor 3, Madrid"])
+    assert match is not None
+    assert match.score < 0.2
+    assert match.detail.startswith("-")


### PR DESCRIPTION
## Summary

- New `rigour.addresses.match_addresses(queries, results) -> AddressMatch | None` returns the best pair of a list×list address comparison with the evidence behind it: `score`, the raw `query` and `result` strings that won, and a one-line `detail`.
- `detail` is a diff-style token line: aligned tokens in query order (`berlin`, `boulevard~blvd` for fuzzy / keyword-alias / territory-code pairs), then `-tok` for query-only and `+tok` for result-only tokens. Example: `sunset boulevard~blvd 12 -los -angeles +la`.
- `compare_address` and `compare_address_many` share the same inner loop and keep returning only the score. Scores are unchanged.
- The alignment writes its bound pairs into a reused scratch buffer that is swapped into the winner's slot on improvement, so the hot N×M loop allocates nothing per pair and the detail string is built once, for the winner.

This lets nomenklatura's `_address_match` fill `FtResult(score, detail, query, candidate)` from one call instead of rebuilding its own detail text.

## Test plan

- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings` (with and without `--features python`), `cargo fmt --check`
- [x] `pytest --cov rigour` (535 passed), `mypy --strict rigour`
- [x] `mkdocs build --strict`
- [x] `contrib/address_bench/evaluate.py --scorer rust`: AUC 0.936, best threshold 0.292 (matches the documented ~0.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)