### PR TITLE
Keep spacing combining marks in address tokenisation and cleanup

### DIFF
--- a/rigour/addresses/normalize.py
+++ b/rigour/addresses/normalize.py
@@ -21,7 +21,8 @@ TOKEN_SEP_CATEGORIES: Categories = {
     "Cn": None,
     "Lm": None,
     "Mn": None,
-    "Mc": WS,
+    # Mc (spacing marks, e.g. Devanagari vowel signs) is deliberately
+    # absent: it is part of the syllable and must not split the token.
     "Me": None,
     "No": None,
     "Zs": WS,

--- a/rust/src/text/normalize.rs
+++ b/rust/src/text/normalize.rs
@@ -66,14 +66,15 @@ pub enum CharAction {
     Whitespace,
 }
 
-// Strong — aggressive cleanup, matches normality.constants.UNICODE_CATEGORIES.
+// Strong — aggressive cleanup, matches normality.constants.UNICODE_CATEGORIES
+// except that Mc (spacing marks) is kept: Brahmic vowel signs belong to
+// their syllable, and turning them into whitespace splits words.
 fn action_strong(cat: GeneralCategory) -> CharAction {
     use GeneralCategory::*;
     match cat {
         Control => CharAction::Whitespace, // Cc
         Format | Surrogate | PrivateUse | Unassigned => CharAction::Delete, // Cf/Cs/Co/Cn
         ModifierLetter | NonspacingMark | EnclosingMark => CharAction::Delete, // Lm/Mn/Me
-        SpacingMark => CharAction::Whitespace, // Mc
         OtherNumber => CharAction::Delete, // No
         SpaceSeparator | LineSeparator | ParagraphSeparator => CharAction::Whitespace, // Zs/Zl/Zp
         ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation
@@ -85,17 +86,16 @@ fn action_strong(cat: GeneralCategory) -> CharAction {
     }
 }
 
-// Slug — matches normality.constants.SLUG_CATEGORIES.
-// Differences from Strong: Lm & Mn are kept (not deleted); Cc is deleted
-// (not replaced with WS).
+// Slug — matches normality.constants.SLUG_CATEGORIES, with Mc kept as
+// in Strong. Differences from Strong: Lm & Mn are kept (not deleted);
+// Cc is deleted (not replaced with WS).
 fn action_slug(cat: GeneralCategory) -> CharAction {
     use GeneralCategory::*;
     match cat {
         Control | Format | Surrogate | PrivateUse | Unassigned => CharAction::Delete, // Cc/Cf/Cs/Co/Cn
         // Lm (ModifierLetter) and Mn (NonspacingMark) fall through to Keep.
-        EnclosingMark => CharAction::Delete,   // Me
-        SpacingMark => CharAction::Whitespace, // Mc
-        OtherNumber => CharAction::Delete,     // No
+        EnclosingMark => CharAction::Delete, // Me
+        OtherNumber => CharAction::Delete,   // No
         SpaceSeparator | LineSeparator | ParagraphSeparator => CharAction::Whitespace,
         ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation
         | InitialPunctuation | FinalPunctuation | OtherPunctuation => CharAction::Whitespace,
@@ -450,6 +450,20 @@ mod tests {
         assert_eq!(
             normalize("!!!", Normalize::SQUASH_SPACES, Cleanup::Strong),
             None
+        );
+    }
+
+    #[test]
+    fn cleanup_keeps_spacing_marks() {
+        // U+0940 DEVANAGARI VOWEL SIGN II (Mc) stays attached under both
+        // profiles; U+094D VIRAMA (Mn) is deleted by Strong only.
+        assert_eq!(
+            normalize("हिन्दी", Normalize::empty(), Cleanup::Strong),
+            Some("हिनदी".to_string())
+        );
+        assert_eq!(
+            normalize("हिन्दी", Normalize::empty(), Cleanup::Slug),
+            Some("हिन्दी".to_string())
         );
     }
 

--- a/rust/src/text/tokenize.rs
+++ b/rust/src/text/tokenize.rs
@@ -125,17 +125,16 @@ const ADDRESS_KEEP_CHARS: &[char] = &[
     '\u{2116}', // NUMERO SIGN № (So)
 ];
 
-// Address category mapping. Differs from the name table in two
-// places: Mc (spacing marks) separates instead of being kept —
-// matching `TOKEN_SEP_CATEGORIES` in the Python address normalizer —
-// and ADDRESS_KEEP_CHARS overrides two symbol codepoints in the
-// caller before this lookup.
+// Address category mapping. Differs from the name table only in
+// ADDRESS_KEEP_CHARS, which overrides two symbol codepoints in the
+// caller before this lookup. Mc (spacing marks) is kept here as in the
+// name table: Brahmic vowel signs are part of their syllable, and
+// splitting on them fragments Indic addresses into consonant runs.
 fn category_action_address(cat: GeneralCategory) -> CharAction {
     use GeneralCategory::*;
     match cat {
         // Whitespace / token separator
-        Control => CharAction::Whitespace,     // Cc
-        SpacingMark => CharAction::Whitespace, // Mc
+        Control => CharAction::Whitespace, // Cc
         SpaceSeparator | LineSeparator | ParagraphSeparator => CharAction::Whitespace, // Zs/Zl/Zp
         ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation
         | InitialPunctuation | FinalPunctuation | OtherPunctuation => CharAction::Whitespace, // Pc/Pd/Ps/Pe/Pi/Pf/Po
@@ -159,9 +158,8 @@ fn category_action_address(cat: GeneralCategory) -> CharAction {
 /// separation. `token_min_length` counts codepoints, not bytes.
 ///
 /// Same single-pass shape as [`tokenize_name`] over a separate
-/// category table: spacing marks (Mc) separate tokens, and the
-/// address signifier symbols `&` and `№` are kept as token content
-/// instead of splitting on them. Decimal-digit runs are emitted as
+/// category table: the address signifier symbols `&` and `№` are
+/// kept as token content instead of splitting on them. Decimal-digit runs are emitted as
 /// their own tokens ("д39" → "д 39", "30th" → "30 th") so glued
 /// house numbers become comparable — the ordinal needles in the
 /// address tagger re-capture split pairs like "30 th".
@@ -362,11 +360,12 @@ mod tests {
     }
 
     #[test]
-    fn address_mc_separates() {
+    fn address_mc_kept() {
         // U+0940 DEVANAGARI VOWEL SIGN II is Mc: token content for
-        // names, a separator for addresses.
+        // both names and addresses.
         assert_eq!(tok("की"), vec!["की"]);
-        assert_eq!(tok_addr("की"), vec!["क"]);
+        assert_eq!(tok_addr("की"), vec!["की"]);
+        assert_eq!(tok_addr("हिन्दुस्तान"), vec!["हिनदसतान"]);
     }
 
     #[test]

--- a/tests/addresses/test_normalize.py
+++ b/tests/addresses/test_normalize.py
@@ -175,3 +175,9 @@ def test_remove_address_keywords_does_not_collapse_whitespace():
     # Three consecutive matched forms → multiple whitespace runs.
     # Non-collapsed whitespace will produce >1 consecutive space.
     assert "  " in removed
+
+
+def test_normalize_address_keeps_spacing_marks():
+    # Devanagari vowel signs (Mc) stay attached; the virama (Mn) is dropped.
+    assert normalize_address("हिन्दुस्तान") == "हिनदसतान"
+    assert normalize_address("नई दिल्ली, भारत") == "नई दिलली भारत"

--- a/tests/text/test_normalize.py
+++ b/tests/text/test_normalize.py
@@ -234,3 +234,8 @@ _STOPWORD_KEY_CASES = [
 @pytest.mark.parametrize("inp,expected", _STOPWORD_KEY_CASES)
 def test_stopword_key_pipeline(inp: str, expected: str | None) -> None:
     assert normalize(inp, _STOPWORD_KEY_FLAGS, _STOPWORD_KEY_CLEANUP) == expected
+
+
+def test_cleanup_keeps_spacing_marks() -> None:
+    assert normalize("हिन्दी", Normalize(0), Cleanup.Strong) == "हिनदी"
+    assert normalize("हिन्दी", Normalize(0), Cleanup.Slug) == "हिन्दी"


### PR DESCRIPTION
## Why

Spacing combining marks (Unicode category Mc) carry vowels in Brahmic scripts: Devanagari ि and ा, Bengali ি, Tamil ா and ு. Three places treated them as word separators, so Indic text fragmented into consonant runs:

| input | before | after |
|---|---|---|
| `normalize_address("हिन्दुस्तान")` | `ह नदसत न` | `हिनदसतान` |
| `normalize_address("நई दिल्ली, भारत")` | `नई द लल भ रत` | `नई दिलली भारत` |
| `tokenize_address("की")` | `["क"]` | `["की"]` |

The name tokenizer already kept Mc as token content (its comment calls it an intentional keep), so the two tokenizers disagreed. The address rule came from the old Python `TOKEN_SEP_CATEGORIES`, which mirrors normality's table; the same defect exists there.

## What

- `rust/src/text/tokenize.rs`: the address category table no longer maps Mc to whitespace; it falls through to Keep like the name table.
- `rust/src/text/normalize.rs`: both `Cleanup::Strong` and `Cleanup::Slug` keep Mc. Comments note the deliberate divergence from normality's category tables.
- `rigour/addresses/normalize.py`: Mc removed from `TOKEN_SEP_CATEGORIES`.
- Tests in Rust and Python pin Devanagari behaviour under both cleanups and in the address normaliser.

Non-spacing marks (Mn) are unchanged: still deleted by Strong and the tokenizers, kept by Slug. That is right for Latin diacritics and Arabic/Hebrew pointing but lossy for the virama and several Indic and Thai vowel signs; a script-aware rule is a separate design question.

## Verification

clippy clean with and without `--features python`, 267 Rust tests pass, mypy strict passes, Python address, text and tokenizer tests pass against the rebuilt extension. Latin, Cyrillic and CJK output is byte-identical since Mc does not occur in those scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
